### PR TITLE
add a more helpful error message for users that encounter #55

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -24,8 +24,26 @@ const FILE_HEADER = "$(REQUIRED_FILE_HEADER)$(CURRENT_VERSION)\x00 (Julia $(VERS
 
 struct UnsupportedVersionException <: Exception end
 struct UnsupportedFeatureException <: Exception end
-struct InvalidDataException <: Exception end
 struct InternalError <: Exception end
+struct InvalidDataException <: Exception msg::String end
+
+InvalidDataException() = InvalidDataException("")
+
+Base.show(io::IO, exception::InvalidDataException) =
+    print(io, "InvalidDataException\n", exception.msg)
+
+@noinline function mmap_may_have_failed()
+    msg = """
+    Some network file systems do not properly implement mmap. As a result of
+    this, you may have experienced data loss. JLD2 may be directed to not use
+    mmap as follows:
+
+        jldopen("file.jld2", true, true, true, IOStream) do file
+            file["object"] = object
+        end
+    """
+    throw(InvalidDataException(msg))
+end
 
 include("Lookup3.jl")
 include("mmapio.jl")

--- a/src/object_headers.jl
+++ b/src/object_headers.jl
@@ -44,6 +44,7 @@ define_packed(ObjectStart)
 # and (payload) size. Returns the size.
 function read_obj_start(io::IO)
     os = read(io, ObjectStart)
+    os.signature != 0x00000000 || mmap_may_have_failed()
     os.signature == OBJECT_HEADER_SIGNATURE || throw(InvalidDataException())
     os.version == 2 || throw(UnsupportedVersionException())
 


### PR DESCRIPTION
This is my proposal for an expanded error message for users that encounter #55. This will point them in the right direction as opposed to the original terse `InvalidDataException()` message.

It would be nice to have a `jldopen(..., mmap=false)` method though :)

This is what it looks like in the wild:
```
julia> file["0142"] # try to read the missing object in my file
ERROR: InvalidDataException
Some network file systems do not properly implement mmap. As a result of
this, you may have experienced data loss. JLD2 may be directed to not use
mmap as follows:

    jldopen("file.jld2", true, true, true, IOStream) do file
        file["object"] = object
    end

Stacktrace:
 [1] mmap_may_have_failed() at /home/mweastwood/julia-packages/v0.6/JLD2/src/JLD2.jl:45
 [2] read_obj_start(::JLD2.MmapIO) at /home/mweastwood/julia-packages/v0.6/JLD2/src/object_headers.jl:47
 [3] isgroup(::JLD2.JLDFile{JLD2.MmapIO}, ::JLD2.RelOffset) at /home/mweastwood/julia-packages/v0.6/JLD2/src/object_headers.jl:75
 [4] getindex(::JLD2.Group{JLD2.JLDFile{JLD2.MmapIO}}, ::String) at /home/mweastwood/julia-packages/v0.6/JLD2/src/groups.jl:103
 [5] getindex(::JLD2.JLDFile{JLD2.MmapIO}, ::String) at /home/mweastwood/julia-packages/v0.6/JLD2/src/JLD2.jl:350
```

Thoughts/comments?