### PR TITLE
Make save macro supports append mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ The code here should work on Julia 0.6. It has extensive unit tests, but it has 
 
 ### `@save` and `@load` macros
 
-The `@save` and `@load` macros are the simplest way to interact with a JLD2 file. The `@save` macro writes one or more variables from the current scope to the JLD file. For example:
+The `@save` and `@load` macros are the simplest way to interact with a JLD2 file.
+The `@save` macro writes one or more variables from the current scope to the JLD file.
+For example:
 
 ```julia
 using JLD2, FileIO
@@ -21,7 +23,15 @@ foo = :bar
 @save "example.jld2" hello foo
 ```
 
-This writes the variables `hello` and `foo` to datasets in a new JLD2 file named `example.jld2`. The `@load` macro loads variables out of a JLD2 file:
+This writes the variables `hello` and `foo` to datasets in a new JLD2 file named `example.jld2`.
+If you want to save variables with append mode, specify `mode = "r+"` to this macro.
+
+```julia
+baz = :qwe
+@save "example.jld2" mode = "r+" baz
+```
+
+The `@load` macro loads variables out of a JLD2 file:
 
 ```julia
 @load "example.jld2" hello foo

--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -280,11 +280,11 @@ end
 
 Opens a JLD file at path `fname`.
 
-`"r"`: Open for reading only, failing if no file exists
-`"r+"`: Open for reading and writing, failing if no file exists
-`"w"`/`"w+"`: Open for reading and writing, overwriting the file if it already exists
-`"a"`/`"a+"`: Open for reading and writing, creating a new file if none exists, but
-              preserving the existing file if one is present
+- `"r"`: Open for read-only, failing if no file exists.
+- `"r+"`: Open for reading and writing, failing if no file exists.
+- `"w"`/`"w+"`: Open for reading and writing, overwriting the file if it already exists.
+- `"a"`/`"a+"`: Open for reading and writing, creating a new file if none exists, but
+                preserving the existing file if one is present.
 """
 function jldopen(fname::AbstractString, mode::AbstractString="r"; kwargs...)
     (wr, create, truncate) = mode == "r"  ? (false, false, false) :

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -15,7 +15,7 @@ function _extractmode(xs)
           mode = x.args[2]
           @assert(mode ∈ ("r+", "w", "w+", "a", "a+"), "unsupport mode: $mode")
       elseif x isa Symbol
-          push!(vars)
+          push!(vars, x)
       else
           throw(ArgumentError("unsupport expression: `$x`"))
       end
@@ -62,9 +62,8 @@ macro save(filename, vars...)
             end
         end
     else
-        writeexprs = Vector{Expr}()
-        for x ∈ vars
-            push!(writeexprs, :(write(f, $(string(x)), $(esc(x)), wsession)))
+        writeexprs = map(vars) do x
+            :(write(f, $(string(x)), $(esc(x)), wsession))
         end
 
         quote

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -13,7 +13,8 @@ function _extractmode(xs)
   for x ∈ xs
       if x isa Expr && x.head == :(=) && length(x.args) == 2 && x.args[] == :mode
           mode = x.args[2]
-          @assert(mode ∈ ("r+", "w", "w+", "a", "a+"), "unsupport mode: $mode")
+          !(mode ∈ ("r+", "w", "w+", "a", "a+")) && (
+              throw(ArgumentError("unsupport mode: $mode")))
       elseif x isa Symbol
           push!(vars, x)
       else

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -8,20 +8,20 @@ function jldopen(f::Function, args...; kws...)
 end
 
 function _extractmode(xs)
-  mode = "w"
-  vars = sizehint!(Vector{Symbol}(), length(xs))
-  for x ∈ xs
-      if x isa Expr && x.head == :(=) && length(x.args) == 2 && x.args[] == :mode
-          mode = x.args[2]
-          !(mode ∈ ("r+", "w", "w+", "a", "a+")) && (
-              throw(ArgumentError("unsupport mode: $mode")))
-      elseif x isa Symbol
-          push!(vars, x)
-      else
-          throw(ArgumentError("unsupport expression: `$x`"))
-      end
-  end
-  mode, vars
+    mode = "w"
+    vars = sizehint!(Vector{Symbol}(), length(xs))
+    for x ∈ xs
+        if x isa Expr && x.head == :(=) && length(x.args) == 2 && x.args[] == :mode
+            mode = x.args[2]
+            !(mode ∈ ("r+", "w", "w+", "a", "a+")) && (
+                throw(ArgumentError("unsupport mode: $mode")))
+        elseif x isa Symbol
+            push!(vars, x)
+        else
+            throw(ArgumentError("unsupport expression: `$x`"))
+        end
+    end
+    mode, vars
 end
 
 """

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -46,7 +46,7 @@ macro save(filename, vars...)
                 push!(writeexprs, :(write(f, $(string(expr)), $(esc(expr)), wsession)))
             elseif expr isa Expr && expr.head == :(=) && length(expr.args) == 2 && expr.args[] == :mode
                 mode = expr.args[2]
-                @assert(mode ∈ ("r+", "w"), "unsupport mode: $mode")
+                @assert(mode ∈ ("r+", "w", "w+", "a", "a+"), "unsupport mode: $mode")
             end
         end
 

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -7,6 +7,12 @@ function jldopen(f::Function, args...; kws...)
     end
 end
 
+"""
+    @save "/path/file.jld2" [mode = "w"] x...
+
+Save one or more variables into `file.jld2`.
+The argument `mode` is optional, please check `?jldopen` for available modes.
+"""
 macro save(filename, vars...)
     if isempty(vars)
         # Save all variables in the current module

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -90,24 +90,24 @@ mktempdir() do dir
     f = joinpath(dir, "test.jld2")
 
     let (x, y, z) = (1, 2, 3)
-      @save f x  # default mode is "w"
-      @save f mode = "r+" y z
+        @save f x  # default mode is "w"
+        @save f mode = "r+" y z
     end
     let
-      @load f x y z
-      @test (x, y, z) == (1, 2, 3)
+        @load f x y z
+        @test (x, y, z) == (1, 2, 3)
     end
 
     # if unsupport mode
     let x = 42
-      @test_throws ArgumentError @save f mode = "❓" x
+        @test_throws ArgumentError @save f mode = "❓" x
     end
 
     # if unsupport expression
     let
-      @test_throws ArgumentError @save f x = 42
-      @test_throws ArgumentError @save f x + 42
-      @test_throws ArgumentError @save f mode = "a" x = 42
-      @test_throws ArgumentError @save f mode = "a" x + 42
+        @test_throws ArgumentError @save f x = 42
+        @test_throws ArgumentError @save f x + 42
+        @test_throws ArgumentError @save f mode = "a" x = 42
+        @test_throws ArgumentError @save f mode = "a" x + 42
     end
 end

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -89,12 +89,12 @@ save(fn, d)
 mktempdir() do dir
     f = joinpath(dir, "test.jld2")
 
-    let x, y, z = (1, 2, 3)
+    let (x, y, z) = (1, 2, 3)
       @save f x  # default mode is "w"
       @save f mode = "r+" y z
     end
     let
-      @load f
+      @load f x y z
       @test (x, y, z) == (1, 2, 3)
     end
 

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -84,3 +84,30 @@ d = Dict("params/p1" => 1,
          "data" => [[1,2,3], [4.,5.,6]])
 save(fn, d)
 @test load(fn) == d
+
+# Issue #68, mode support for `@save`
+mktempdir() do dir
+    f = joinpath(dir, "test.jld2")
+
+    let x, y, z = (1, 2, 3)
+      @save f x  # default mode is "w"
+      @save f mode = "r+" y z
+    end
+    let
+      @load f
+      @test (x, y, z) == (1, 2, 3)
+    end
+
+    # if unsupport mode
+    let x = 42
+      @test_throws ArgumentError @save f mode = "❓" x
+    end
+
+    # if unsupport expression
+    let
+      @test_throws ArgumentError @save f x = 42
+      @test_throws ArgumentError @save f x + 42
+      @test_throws ArgumentError @save f mode = "a" x = 42
+      @test_throws ArgumentError @save f mode = "a" x + 42
+    end
+end


### PR DESCRIPTION
I ran into this issue as well: https://github.com/JuliaIO/JLD.jl/issues/90
So, I want this macro to be more handy.

```julia
julia> x, y, z = 1:3
1:3

julia> @save "./test.jld2" y

julia> @load "./test.jld2"
1-element Array{Symbol,1}:
 :y

julia> @save "./test.jld2" mode = "r+" x z

julia> @load "./test.jld2"
3-element Array{Symbol,1}:
 :y
 :x
 :z

julia> x, y, z
(1, 2, 3)
```