### PR TITLE
Bug fix: fix typename for nested modules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD2"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.1.5-DEV"
+version = "0.1.6"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/data.jl
+++ b/src/data.jl
@@ -847,17 +847,7 @@ h5type(f::JLDFile, ::Type{T}, x) where {T<:DataType} =
     h5fieldtype(f, DataType, typeof(x), Val{true})
 odr(::Type{T}) where {T<:DataType} = DataTypeODR()
 
-function typename(T::DataType)
-    m = T.name.module
-    tn = Symbol[nameof(m)]
-    while m != parentmodule(m)
-        push!(tn, nameof(m))
-        m = parentmodule(m)
-    end
-    reverse!(tn)
-    push!(tn, T.name.name)
-    join(tn, ".")
-end
+typename(T::DataType) = join([fullname(T.name.module)..., T.name.name], ".")
 
 function h5convert!(out::Pointers, ::DataTypeODR, f::JLDFile, T::DataType, wsession::JLDWriteSession)
     t = typename(T)

--- a/src/data.jl
+++ b/src/data.jl
@@ -847,7 +847,13 @@ h5type(f::JLDFile, ::Type{T}, x) where {T<:DataType} =
     h5fieldtype(f, DataType, typeof(x), Val{true})
 odr(::Type{T}) where {T<:DataType} = DataTypeODR()
 
-typename(T::DataType) = join([fullname(T.name.module)..., T.name.name], ".")
+function typename(T::DataType)
+    s = IOBuffer()
+    join(s, fullname(T.name.module), '.')
+    print(s, '.')
+    print(s, T.name.name)
+    return String(resize!(s.data, s.size))
+end
 
 function h5convert!(out::Pointers, ::DataTypeODR, f::JLDFile, T::DataType, wsession::JLDWriteSession)
     t = typename(T)

--- a/test/internal.jl
+++ b/test/internal.jl
@@ -81,3 +81,12 @@ end
 
 # test with one of its own types
 @test JLD2.typename(JLD2.BasicDatatype) == "JLD2.BasicDatatype"
+@test JLD2.typename(String) == "Core.String"
+
+module Foo
+    module Bar
+        struct Baz end
+    end
+end
+
+@test endswith(JLD2.typename(Foo.Bar.Baz), "Foo.Bar.Baz")

--- a/test/modules-nested.jl
+++ b/test/modules-nested.jl
@@ -392,8 +392,8 @@
         Test.@test result[2] isa Pkg.Types.PackageSpec
         """
 
-        loading_cmd = `$(Base.julia_cmd()) -e $(code)`
-        @test success(cmd)
+        my_cmd = `$(Base.julia_cmd()) -e $(code)`
+        @test success(my_cmd)
 
         cd(original_directory)
         rm(tmpdir; force = true, recursive = true)

--- a/test/modules-nested.jl
+++ b/test/modules-nested.jl
@@ -393,6 +393,7 @@
         """
 
         my_cmd = `$(Base.julia_cmd()) -e $(code)`
+        run(my_cmd)
         @test success(my_cmd)
 
         cd(original_directory)

--- a/test/modules-nested.jl
+++ b/test/modules-nested.jl
@@ -340,7 +340,7 @@
             # Symmetric is correctly loadable
             io["linalg_obj"] = Symmetric(randn(2,2,))
 
-            # PackgeSpec is not loadable, because it's actually Pkg.Types.PackageSpec; it will be "reconstructed"
+            # PackageSpec is actually Pkg.Types.PackageSpec
             io["pkg_types_obj"] = PackageSpec(;name = "Foo")
         end
         @info("Wrote out to test.jld")

--- a/test/modules-nested.jl
+++ b/test/modules-nested.jl
@@ -319,4 +319,83 @@
 
         rm(tmpdir; force = true, recursive = true)
     end
+    @testset "issue #154 - type exists in child module but not in parent module" begin
+        original_directory = pwd()
+        tmpdir = mktempdir()
+        atexit(() -> rm(tmpdir; force = true, recursive = true))
+
+        cd(tmpdir)
+        rm("test.jld"; force = true, recursive = true)
+
+        code = """
+        using JLD2
+
+        # Always start fresh
+        rm("test.jld"; force=true)
+
+        # Write out jld file in child module
+        module Child
+        using JLD2, LinearAlgebra, Pkg
+        jldopen("test.jld", "w") do io
+            # Symmetric is correctly loadable
+            io["linalg_obj"] = Symmetric(randn(2,2,))
+
+            # PackgeSpec is not loadable, because it's actually Pkg.Types.PackageSpec; it will be "reconstructed"
+            io["pkg_types_obj"] = PackageSpec(;name = "Foo")
+        end
+        @info("Wrote out to test.jld")
+
+        # Parent module will call do_read()
+        function do_read()
+            jldopen("test.jld", "r") do io
+                io["linalg_obj"], io["pkg_types_obj"]
+            end
+        end
+        end # module Child
+
+        # Read it out in parent module (where Pkg and LinearAlgebra don't exist)
+        import .Child
+
+        result = Child.do_read()
+
+        import Test
+
+        Test.@test result isa Tuple
+        Test.@test length(result) == 2
+
+        Test.@test size(result[1]) == (2, 2)
+        Test.@test result[1][1][1] isa Float64
+        Test.@test result[1][1][2] isa Float64
+        Test.@test result[1][2][1] isa Float64
+        Test.@test result[1][2][2] isa Float64
+
+        Test.@test result[2].name isa String
+        Test.@test result[2].name == "Foo"
+
+        Test.@test !JLD2.isreconstructed(result)
+
+        Test.@test !JLD2.isreconstructed(result[1])
+        Test.@test !JLD2.isreconstructed(result[1][1][1])
+        Test.@test !JLD2.isreconstructed(result[1][1][2])
+        Test.@test !JLD2.isreconstructed(result[1][2][1])
+        Test.@test !JLD2.isreconstructed(result[1][2][2])
+
+        Test.@test !JLD2.isreconstructed(result[2])
+        Test.@test !JLD2.isreconstructed(result[2].name)
+
+        # NOTE: we do not import Pkg and LinearAlgebra into the parent
+        # module until AFTER we have run `Child.do_read()`
+        import Pkg
+        import LinearAlgebra
+
+        Test.@test result[1] isa LinearAlgebra.Symmetric{Float64,Array{Float64,2}}
+        Test.@test result[2] isa Pkg.Types.PackageSpec
+        """
+
+        loading_cmd = `$(Base.julia_cmd()) -e $(code)`
+        @test success(cmd)
+
+        cd(original_directory)
+        rm(tmpdir; force = true, recursive = true)
+    end
 end

--- a/test/modules-nested.jl
+++ b/test/modules-nested.jl
@@ -364,10 +364,12 @@
         Test.@test length(result) == 2
 
         Test.@test size(result[1]) == (2, 2)
-        Test.@test result[1][1][1] isa Float64
-        Test.@test result[1][1][2] isa Float64
-        Test.@test result[1][2][1] isa Float64
-        Test.@test result[1][2][2] isa Float64
+        @info("", length(result[1]))
+        Test.@test length(result[1]) == 4
+        Test.@test result[1][1] isa Float64
+        Test.@test result[1][2] isa Float64
+        Test.@test result[1][3] isa Float64
+        Test.@test result[1][4] isa Float64
 
         Test.@test result[2].name isa String
         Test.@test result[2].name == "Foo"
@@ -375,10 +377,10 @@
         Test.@test !JLD2.isreconstructed(result)
 
         Test.@test !JLD2.isreconstructed(result[1])
-        Test.@test !JLD2.isreconstructed(result[1][1][1])
-        Test.@test !JLD2.isreconstructed(result[1][1][2])
-        Test.@test !JLD2.isreconstructed(result[1][2][1])
-        Test.@test !JLD2.isreconstructed(result[1][2][2])
+        Test.@test !JLD2.isreconstructed(result[1][1])
+        Test.@test !JLD2.isreconstructed(result[1][2])
+        Test.@test !JLD2.isreconstructed(result[1][3])
+        Test.@test !JLD2.isreconstructed(result[1][4])
 
         Test.@test !JLD2.isreconstructed(result[2])
         Test.@test !JLD2.isreconstructed(result[2].name)

--- a/test/modules-nested.jl
+++ b/test/modules-nested.jl
@@ -364,7 +364,6 @@
         Test.@test length(result) == 2
 
         Test.@test size(result[1]) == (2, 2)
-        @info("", length(result[1]))
         Test.@test length(result[1]) == 4
         Test.@test result[1][1] isa Float64
         Test.@test result[1][2] isa Float64
@@ -395,7 +394,6 @@
         """
 
         my_cmd = `$(Base.julia_cmd()) -e $(code)`
-        run(my_cmd)
         @test success(my_cmd)
 
         cd(original_directory)


### PR DESCRIPTION
Fixes #154 
Fixes #112 

I found that in my Julia 1.0+ project: type names in a nested module (or even just `Core.String`) had duplicate module names in the path. e.g. `typname(A.B.C.T) = "A.B.C.C.T"` and also `typename(String) = "Core.Core.String"`.

This patch appears to solve that problem for Julia 1.0+ (and probably 0.7, but I suspect >0.6 needs testing) in my application. However the unit tests fail with:

```
┌ Info: read(
│   ms = Main.__anon__.MyStruct(2, [3.2, -1.7])
└   ) = ")"
┌ Warning: type Main.__anon__.MyStruct does not exist in workspace; reconstructing
└ @ JLD2 ~/.julia/packages/JLD2/Y5CVo/src/data.jl:1143
ERROR: LoadError: LoadError: For ms, read type getfield(JLD2.ReconstructedTypes, Symbol("##Main.__anon__.MyStruct#362")) does not agree with written type Main.__anon__.MyStruct
Stacktrace:
 [1] error(::String, ::String, ::String) at ./error.jl:42
 [2] top-level scope at logging.jl:320
 [3] top-level scope at /home/rich/.julia/dev/JLD2/test/rw.jl:415
 [4] top-level scope at logging.jl:312
 [5] top-level scope at /home/rich/.julia/dev/JLD2/test/rw.jl:361
 [6] include at ./boot.jl:317 [inlined]
 [7] include_relative(::Module, ::String) at ./loading.jl:1041
 [8] include at ./sysimg.jl:29 [inlined]
 [9] include(::String) at ./loading.jl:1076
 [10] top-level scope at none:0
 [11] include at ./boot.jl:317 [inlined]
 [12] include_relative(::Module, ::String) at ./loading.jl:1041
 [13] include at ./sysimg.jl:29 [inlined]
 [14] include(::String) at ./loading.jl:1076
 [15] top-level scope at none:0
 [16] eval at ./boot.jl:319 [inlined]
 [17] evalfile(::String, ::Array{String,1}) at ./loading.jl:1072 (repeats 2 times)
 [18] top-level scope at none:0
in expression starting at /home/rich/.julia/dev/JLD2/test/rw.jl:360
in expression starting at /home/rich/.julia/dev/JLD2/test/runtests.jl:6
```
I can't exec the tests with `Pkg.test` so I'm not even sure whether `MyStruct` should end up in `Main.__anon__` or if I am just not executing the test in the right environment. Assuming it is I am not sure what the expected behaviour is; should it be able to successfully reconstruct the type or should it be able to find it in `Main.__anon__`? The type is defined inside a `try` block which seems necessary unless the `try` block hides the definition to force reconstructing.