### PR TITLE
[RFC] Global compress option

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -205,6 +205,15 @@ Defaults to `false`.
 """
 const COMPRESS = Ref(false)
 
+"""
+Threshold for using the compact storage layout.
+Data items of smaller size will use the compact layout.
+Bigger data items will use either chunked or continuous layout depending on their data type.
+
+Defaults to 8192.
+"""
+const COMPACT_STORAGE_THRESHOLD = Ref(8192)
+
 const OPEN_FILES = Dict{String,WeakRef}()
 function jldopen(fname::AbstractString, wr::Bool, create::Bool, truncate::Bool, iotype::T=MmapIO;
                  compress::Bool=COMPRESS[], mmaparrays::Bool=false) where T<:Union{Type{IOStream},Type{MmapIO}}

--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -197,9 +197,17 @@ openfile(::Type{MmapIO}, fname, wr, create, truncate) =
 # The delimiter is excluded by default
 read_bytestring(io::IOStream) = String(readuntil(io, 0x00))
 
+"""
+Controls whether compression is enabled by default
+(when `jldopen()` is called without specifying `compress` keyarg).
+
+Defaults to `false`.
+"""
+const COMPRESS = Ref(false)
+
 const OPEN_FILES = Dict{String,WeakRef}()
 function jldopen(fname::AbstractString, wr::Bool, create::Bool, truncate::Bool, iotype::T=MmapIO;
-                 compress::Bool=false, mmaparrays::Bool=false) where T<:Union{Type{IOStream},Type{MmapIO}}
+                 compress::Bool=COMPRESS[], mmaparrays::Bool=false) where T<:Union{Type{IOStream},Type{MmapIO}}
     exists = isfile(fname)
     if exists
         rname = realpath(fname)

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -350,8 +350,6 @@ end
 function write_dataset(f::JLDFile, dataspace::WriteDataspace, datatype::H5Datatype, odr::S, data::Array{T}, wsession::JLDWriteSession) where {T,S}
     io = f.io
     datasz = odr_sizeof(odr) * numel(dataspace)
-    layout_class = datasz < 8192 ? LC_COMPACT_STORAGE :
-                   f.compress ? LC_CHUNKED_STORAGE : LC_CONTIGUOUS_STORAGE
     psz = payload_size_without_storage_message(dataspace, datatype)
     if datasz < 8192
         layout_class = LC_COMPACT_STORAGE

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -351,7 +351,7 @@ function write_dataset(f::JLDFile, dataspace::WriteDataspace, datatype::H5Dataty
     io = f.io
     datasz = odr_sizeof(odr) * numel(dataspace)
     psz = payload_size_without_storage_message(dataspace, datatype)
-    if datasz < 8192
+    if datasz < COMPACT_STORAGE_THRESHOLD[]
         layout_class = LC_COMPACT_STORAGE
         psz += sizeof(CompactStorageMessage) + datasz
     elseif f.compress && isconcretetype(T) && isbitstype(T)


### PR DESCRIPTION
The PR adds `JLD2.COMPRESS` var that is used as the default value of `compress` keyarg in `jldopen()` call (`jldopen(..., compress=COMPRESS[])`).
As before, the compression is disabled by default, but the user can change it (`JLD2.COMPRESS[] = true`).
This is especially useful for `@save`, because this macro doesn't support specifying `jldopen()` options, so before this PR `@save` was able to generate uncompressed files only.

I'm not sure about the public interface to control `JLD2.COMPRESS`, though (hence RFC).
Directly assigning it looks straightforward, but dedicated public methods (e.g. `jldcompress(::Bool)`) is an alternative option.

The PR also adds `JLD2.COMPACT_STORAGE_THRESHOLD` (defaults to 8192).
In my case it helps to reduce the size of JLD2 file storing short (fewer rows) and wide (many columns) data frames.

Closes #133 
