### PR TITLE
Corrected saving and loading of strings longer than 2^16 characters.

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -720,9 +720,9 @@ end
 fieldodr(::Type{String}, ::Bool) = Vlen{String}
 
 # Stored as variable-length strings
-struct FixedLengthString{T<:AbstractString}
-    length::Int
-end
+#struct FixedLengthString{T<:AbstractString} # moved to datatypes.jl so visible when datasets.jl included
+#    length::Int
+#end
 odr_sizeof(x::FixedLengthString{String}) = x.length
 
 h5type(f::JLDFile, writeas::Type{String}, x::String) =

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -368,7 +368,6 @@ function deflate_data(f::JLDFile, data::Array{T}, odr::S, wsession::JLDWriteSess
     end
     transcode(ZlibCompressor, buf)
 end
-   
 function write_dataset(f::JLDFile, dataspace::WriteDataspace, datatype::H5Datatype, odr::S, data::Array{T}, wsession::JLDWriteSession) where {T,S}
     io = f.io
     datasz = odr_sizeof(odr) * numel(dataspace)

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -329,21 +329,8 @@ function read_array(f::JLDFile, dataspace::ReadDataspace,
                     rr::FixedLengthString{String}, data_length::Int,
                     filter_id::UInt16, header_offset::RelOffset,
                     attributes::Union{Vector{ReadAttribute},Nothing}) 
-    io = f.io
-    data_offset = position(io)
-    ndims, offset = get_ndims_offset(f, dataspace, attributes)
-    seek(io, offset)
-    T = UInt8
-    v = construct_array(io, T, Int(ndims))
-    header_offset !== NULL_REFERENCE && (f.jloffset[header_offset] = WeakRef(v))
-    n = length(v)
-    seek(io, data_offset)
-    rrv = ReadRepresentation{T,odr(T)}()
-    if filter_id == 1
-        read_compressed_array!(v, f, rrv, data_length)
-    else
-        read_array!(v, f, rrv)
-    end
+    rrv = ReadRepresentation{UInt8,odr(UInt8)}()
+    v = read_array(f, dataspace, rrv, data_length, filter_id, header_offset, attributes)
     String(v)
 end
 

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -325,6 +325,28 @@ function read_array(f::JLDFile, dataspace::ReadDataspace,
     v
 end
 
+function read_array(f::JLDFile, dataspace::ReadDataspace,
+                    rr::FixedLengthString{String}, data_length::Int,
+                    filter_id::UInt16, header_offset::RelOffset,
+                    attributes::Union{Vector{ReadAttribute},Nothing}) 
+    io = f.io
+    data_offset = position(io)
+    ndims, offset = get_ndims_offset(f, dataspace, attributes)
+    seek(io, offset)
+    T = UInt8
+    v = construct_array(io, T, Int(ndims))
+    header_offset !== NULL_REFERENCE && (f.jloffset[header_offset] = WeakRef(v))
+    n = length(v)
+    seek(io, data_offset)
+    rrv = ReadRepresentation{T,odr(T)}()
+    if filter_id == 1
+        read_compressed_array!(v, f, rrv, data_length)
+    else
+        read_array!(v, f, rrv)
+    end
+    String(v)
+end
+
 function payload_size_without_storage_message(dataspace::WriteDataspace, datatype::H5Datatype)
     sz = 6 + 4 + sizeof(dataspace) + 4 + sizeof(datatype) + length(dataspace.attributes)*sizeof(HeaderMessage)
     for attr in dataspace.attributes
@@ -346,7 +368,7 @@ function deflate_data(f::JLDFile, data::Array{T}, odr::S, wsession::JLDWriteSess
     end
     transcode(ZlibCompressor, buf)
 end
-
+   
 function write_dataset(f::JLDFile, dataspace::WriteDataspace, datatype::H5Datatype, odr::S, data::Array{T}, wsession::JLDWriteSession) where {T,S}
     io = f.io
     datasz = odr_sizeof(odr) * numel(dataspace)
@@ -519,6 +541,12 @@ end
 @inline function write_dataset(f::JLDFile, x, wsession::JLDWriteSession)
     odr = objodr(x)
     write_dataset(f, WriteDataspace(f, x, odr), h5type(f, x), odr, x, wsession)
+end
+
+@inline function write_dataset(f::JLDFile, s::String, wsession::JLDWriteSession)
+    x=unsafe_wrap(Vector{UInt8}, s)
+    odr = objodr(x)
+    write_dataset(f, WriteDataspace(f, x, odr), h5type(f, s), odr, x, wsession)
 end
 
 @inline function write_ref_mutable(f::JLDFile, x, wsession::JLDWriteSession)

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -301,3 +301,8 @@ function read_committed_datatype(f::JLDFile, cdt::CommittedDatatype)
         return (dt, attrs)
     end
 end
+
+
+struct FixedLengthString{T<:AbstractString} # moved to datatypes.jl so visible when datasets.jl included
+    length::Int
+end

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -303,6 +303,6 @@ function read_committed_datatype(f::JLDFile, cdt::CommittedDatatype)
 end
 
 
-struct FixedLengthString{T<:AbstractString} # moved to datatypes.jl so visible when datasets.jl included
+struct FixedLengthString{T<:AbstractString} 
     length::Int
 end

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -99,3 +99,11 @@ Base.isequal(x::MyMutableTest, y::MyMutableTest) =
 mmtd = Dict("A" => MyMutableTest(1, [10]))
 save(fn, mmtd)
 @test isequal(load(fn), mmtd)
+
+# Issue #125
+len = 2^16
+longstring = prod(fill("*",len));
+lsd = Dict("longstring" => longstring)
+save(fn, lsd)
+@test isequal(load(fn), lsd)  
+


### PR DESCRIPTION
This fixes #125. 

Strings are converted to Vector{UInt8} for writing and reading. This makes sure that long strings are correctly handled as chunked or contiguous storage. The previous code always treated strings as compact storage, which fails when the size is larger than 2^16. 