### PR TITLE
Always search the Main module first

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD2"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/data.jl
+++ b/src/data.jl
@@ -915,7 +915,9 @@ function _resolve_type(rr::ReadRepresentation{T,DataTypeODR()},
                        hasparams::Bool,
                        params) where T
     parts = split(mypath, '.')
-    for mod in Iterators.flatten((keys(Base.module_keys), stdlibmodules(Main)))
+    modules = vcat([Main], collect(keys(Base.module_keys)), stdlibmodules(Main))
+    unique!(modules)
+    for mod in modules
         resolution_attempt = _resolve_type_singlemodule(rr,
                                                         mod,
                                                         parts,


### PR DESCRIPTION
In the good old days of JLD2 `0.1.2`, we only searched the `Main` module when trying to resolve a type. If we could not find the type in `Main`, we gave up.

In the subsequent bugfix releases of JLD2, we added code to make JLD2 work harder to find the type. However, when we made those changes, we did not preserve the order in which modules are searched. As a result, the latest release of JLD2 does not necessarily search the `Main` module first.

This pull request ensures that we always search the `Main` module first before searching other modules.

## Motivation

In my use case, I have a custom struct `Foo` which has a field of type `StatsModels.Schema`. My list of loaded modules in `Base.module_keys` includes `StatsModels`, `ScientificTypes`, and `Tables`.

It turns out that all three of those modules defines their own `Schema` type. I.e. there is `StatsModels.Schema`, `ScientificTypes.Schema`, and `Tables.Schema`, none of which are equal to each other.

So, when I try to load `Foo` from a JLD2 file, JLD2 goes searching through all of the modules in `Base.module_keys`. Now, here is the problem: we have no control over the order in which the iterator `keys(Base.module_keys)` returns the modules.

If we happen to search `StatsModels` before the other modules, then great. But sometimes, JLD2 will search `ScientificTypes` or `Tables` before searching `StatsModels`, then JLD2 finds either `ScientificTypes.Schema` or `Tables.Schema`, and thinks that this is the correct type.

It turns out that the solution for this is actually really easy! Just run this line in the top-level scope, i.e. in the `Main` scope:
```julia
const Schema = StatsModels.Schema
```

Now we have defined `Main.Schema`. So if JLD2 searches the `Main` module first, it will find `Main.Schema`, which is what we want it to find.

But this only works if JLD2 searches the `Main` module first. This was the behavior in JLD `0.1.2`, and it is the correct behavior. We should always search the `Main` module first, before we search other modules.

So this pull request restores the correct behavior from `0.1.2`.