### PR TITLE
Fix a bug that occurs because `Future` is a stdlib but also a type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD2"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/stdlib.jl
+++ b/src/stdlib.jl
@@ -42,7 +42,10 @@ function stdlibmodules(m::Module)::Vector{Module}
     for x in values(stdlib())
         s = Symbol(x)
         if isdefined(m, s)
-            push!(result, getproperty(m, s))
+            m_dot_s = getproperty(m, s)
+            if m_dot_s isa Module
+                push!(result, m_dot_s)
+            end
         end
     end
     return result


### PR DESCRIPTION
There is a stdlib module named Future.

There is also a type Distributed.Future, and this type is exported.

This causes the bug https://github.com/JuliaIO/JLD2.jl/issues/165

This PR fixes the bug.

Fixes #165 