### PR TITLE
use full type path in type resolution

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD2"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/data.jl
+++ b/src/data.jl
@@ -891,9 +891,9 @@ function _resolve_type_singlemodule(::ReadRepresentation{T,DataTypeODR()},
                                     mypath,
                                     hasparams::Bool,
                                     params) where T
-    for part in parts[2:end]
+    for part in parts
         sym = Symbol(part)
-        if !isdefined(m, sym)
+        if !isa(m, Module) || !isdefined(m, sym)
             return hasparams ? UnknownType(mypath, params) : UnknownType(mypath)
         end
         m = getfield(m, sym)

--- a/test/A.jl
+++ b/test/A.jl
@@ -6,4 +6,8 @@ struct AType
 	x::Int
 end
 
+struct SameNameType{T}
+    x::T
+end
+
 end

--- a/test/B.jl
+++ b/test/B.jl
@@ -8,4 +8,8 @@ struct BType
 	x::AType
 end
 
+struct SameNameType
+    y::Int
+end
+
 end

--- a/test/modules.jl
+++ b/test/modules.jl
@@ -21,4 +21,16 @@ S = BType(x)
 	@test T == S
 end
 
+@testset "name collisions" begin
+    mods = collect(keys(Base.module_keys))
+    # use whichever module would not be found first in a linear search
+    M = findfirst(==(A), mods) < findfirst(==(B), mods) ? B : A
+    x = M.SameNameType(42)
+    file = joinpath(mktempdir(), "collision.jld")
+    @save file x
+    x = nothing
+    @load file x
+    @test x isa M.SameNameType
+end
+
 end


### PR DESCRIPTION
Currently a non-deterministic bug is possible if two different modules have a type with the same name. `_resolve_type` drops the first path component (the top-level module) and instead searches all modules in hash order. This fixes it by just using the whole path. I believe this was introduced by 9ef1e0979b2b7b92e46a33d025b80bc4232bb611. If this looks good I'll add a test.