### PR TITLE
Add warning about using mmaparrays keyword

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -200,6 +200,7 @@ read_bytestring(io::IOStream) = String(readuntil(io, 0x00))
 const OPEN_FILES = Dict{String,WeakRef}()
 function jldopen(fname::AbstractString, wr::Bool, create::Bool, truncate::Bool, iotype::T=MmapIO;
                  compress::Bool=false, mmaparrays::Bool=false) where T<:Union{Type{IOStream},Type{MmapIO}}
+    mmaparrays && @warn "mmaparrays keyword is currently ignored" maxlog=1
     exists = isfile(fname)
     if exists
         rname = realpath(fname)


### PR DESCRIPTION
The current behavior is to silently accept the keyword.
```julia
import HDF5, JLD, JLD2

function writetest(f::Function, g::Function; kwargs...)
    y = f("foo", "w"; kwargs...) do j
        x = ones(Int,2)
        j["x"] = x
        @show x
        x
    end

    f("foo", "r+"; kwargs...) do j
        x = g(j["x"])
        x[2] = 10 
        @show x[:]
    end

    f("foo", "r"; kwargs...) do j
        x = g(j["x"])
        @show x[:]
    
       if y == x
           println("did NOT update")
       else
           println("did update")
       end
   end
end

function mmaptest()
    println("HDF5")
    writetest(HDF5.h5open, HDF5.readmmap)
    println("JLD")
    writetest(JLD.jldopen, x -> x; mmaparrays=true)
    println("JLD2")
    writetest(JLD2.jldopen, x -> x; mmaparrays=true)
end
```
And the result
```julia
julia> mmaptest()
HDF5
x = [1, 1]
x[:] = [1, 10]
x[:] = [1, 10]
did update
JLD
x = [1, 1]
x[:] = [1, 10]
x[:] = [1, 10]
did update
JLD2
x = [1, 1]
x[:] = [1, 10]
x[:] = [1, 1]
did NOT update
```