### PR TITLE
Allow saving of 'recursive' immutable structs

### DIFF
--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -105,5 +105,23 @@ len = 2^16
 longstring = prod(fill("*",len));
 lsd = Dict("longstring" => longstring)
 save(fn, lsd)
-@test isequal(load(fn), lsd)  
+@test isequal(load(fn), lsd)
 
+# Issue # 189
+struct RecursiveStruct
+    x::RecursiveStruct
+    RecursiveStruct() = new()
+    RecursiveStruct(x) = new(x)
+end
+
+
+@testset "Recursive Immutable Types" begin
+    x = RecursiveStruct()
+    y = RecursiveStruct(x)
+
+    @save "out.jld2" x y
+    JLD2.jldopen("out.jld2", "r") do f
+        @test f["x"] == x
+        @test f["y"] == y
+    end
+end


### PR DESCRIPTION
When serializing immutable structs, `JLD2` attempts to generate an *in-line* representation for the given struct.
It does so by recursively trying to find the memory layout of all immutable fields.
This is neat for many applications but it fails when encountering recursive structs e.g.
```
struct RecursiveStruct
    x::RecursiveStruct
    RecursiveStruct() = new()
    RecursiveStruct(x) = new(x)
end
```

This PR modifies the relevant function `hasfielddata` and `hasdata` to look for such recursive structs.
The functions now track which types they already have encountered and terminate the inlineing 
when a type signature is encountered again.

closes #189