### PR TITLE
Magic Bytes

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -11,18 +11,13 @@ const OBJECT_HEADER_SIGNATURE = htol(0x5244484f) # "OHDR"
 # Currently we specify that all offsets and lengths are 8 bytes
 const Length = UInt64
 
-# Currently we specify a 512 byte header
-const FILE_HEADER_LENGTH = 512
-const CURRENT_VERSION = v"0.2"
-const REQUIRED_FILE_HEADER = "Julia data file (HDF5), version "
-const FILE_HEADER = "$(REQUIRED_FILE_HEADER)$(CURRENT_VERSION)\x00 (Julia $(VERSION) $(sizeof(Int)*8)-bit $(htol(1) == 1 ? "LE" : "BE"))\x00"
-@assert length(FILE_HEADER) <= FILE_HEADER_LENGTH
 
 struct UnsupportedVersionException <: Exception end
 struct UnsupportedFeatureException <: Exception end
 struct InvalidDataException <: Exception end
 struct InternalError <: Exception end
 
+include("file_header.jl")
 include("Lookup3.jl")
 include("mmapio.jl")
 include("bufferedio.jl")
@@ -239,18 +234,7 @@ function jldopen(fname::AbstractString, wr::Bool, create::Bool, truncate::Bool, 
         f.root_group = Group{typeof(f)}(f)
         f.types_group = Group{typeof(f)}(f)
     else
-        if String(read!(io, Vector{UInt8}(undef, length(REQUIRED_FILE_HEADER)))) != REQUIRED_FILE_HEADER
-            throw(ArgumentError(string('"', fname, "\" is not a JLD file")))
-        end
-
-        ver = VersionNumber(read_bytestring(io))
-        if ver < v"0.2"
-            throw(ArgumentError("only JLD2 files are presently supported"))
-        elseif ver > CURRENT_VERSION
-            @warn("\"$fname\" was written in JLD file format version $ver" *
-                 ", but this version of JLD supports only JLD file format $CURRENT_VERSION" *
-                 ". Some or all data in the file may not be readable")
-        end
+        verify_file_header(f)
 
         seek(io, FILE_HEADER_LENGTH)
         superblock = read(io, Superblock)

--- a/src/file_header.jl
+++ b/src/file_header.jl
@@ -1,0 +1,37 @@
+# Currently we specify a 512 byte header
+const FILE_HEADER_LENGTH = 512
+
+const FORMAT_VERSION = v"0.1"
+const REQUIRED_FILE_HEADER = "HDF5-based Julia Data Format, version "
+const FILE_HEADER = "$(REQUIRED_FILE_HEADER)$(FORMAT_VERSION)\x00 (Julia $(VERSION) $(sizeof(Int)*8)-bit $(htol(1) == 1 ? "LE" : "BE"))\x00"
+
+# Legacy File Header
+const LEGACY_REQUIRED_FILE_HEADER = "Julia data file (HDF5), version 0.2.0"
+
+@assert length(FILE_HEADER) <= FILE_HEADER_LENGTH
+
+
+function verify_file_header(f)
+    io = f.io
+    fname = f.path
+    seek(io, 0)
+    headermsg = String(read!(io, Vector{UInt8}(undef, length(REQUIRED_FILE_HEADER))))
+    if headermsg != REQUIRED_FILE_HEADER
+        if !startswith(headermsg, LEGACY_REQUIRED_FILE_HEADER)
+            throw(ArgumentError(string('"', fname, "\" is not a JLD2 file")))
+        else
+            @warn("This file was written with an older version of JLD2. Attempting to load data.", maxlog=1)
+            return
+        end
+    end
+
+    ver = VersionNumber(read_bytestring(io))
+    if ver < FORMAT_VERSION
+        #throw(ArgumentError("only JLD2 files are presently supported"))
+        @warn("This file was written with an older version of JLD2. Attempting to load data.", maxlog=1)
+    elseif ver > FORMAT_VERSION
+        @warn("""This file was written in a newer version of the JLD2 file format.
+        Please consider updating JLD2. Attempting to load data.
+        """, maxlog=1)
+    end
+end

--- a/src/file_header.jl
+++ b/src/file_header.jl
@@ -10,11 +10,10 @@ const FORMAT_VERSION = v"0.1.0"
 const COMPATIBLE_VERSIONS = VersionRange("0.1")
 const REQUIRED_FILE_HEADER = "HDF5-based Julia Data Format, version "
 const FILE_HEADER = "$(REQUIRED_FILE_HEADER)$(FORMAT_VERSION)\x00 (Julia $(VERSION) $(sizeof(Int)*8)-bit $(htol(1) == 1 ? "LE" : "BE"))\x00"
+@assert length(FILE_HEADER) <= FILE_HEADER_LENGTH
 
 # Legacy File Header
 const LEGACY_REQUIRED_FILE_HEADER = "Julia data file (HDF5), version 0.2.0"
-
-@assert length(FILE_HEADER) <= FILE_HEADER_LENGTH
 
 
 function verify_file_header(f)

--- a/src/file_header.jl
+++ b/src/file_header.jl
@@ -7,7 +7,7 @@ const FORMAT_VERSION = v"0.1.0"
 # Range of file format versions that can be read
 # Publish patch release relaxing upper version bound
 # if the imminent major release is not breaking
-const COMPATIBLE_VERSIONS = VersionRange("0.2.0-0.1.0")
+const COMPATIBLE_VERSIONS = VersionRange("0.1")
 const REQUIRED_FILE_HEADER = "HDF5-based Julia Data Format, version "
 const FILE_HEADER = "$(REQUIRED_FILE_HEADER)$(FORMAT_VERSION)\x00 (Julia $(VERSION) $(sizeof(Int)*8)-bit $(htol(1) == 1 ? "LE" : "BE"))\x00"
 

--- a/src/file_header.jl
+++ b/src/file_header.jl
@@ -20,7 +20,7 @@ function verify_file_header(f)
         if !startswith(headermsg, LEGACY_REQUIRED_FILE_HEADER)
             throw(ArgumentError(string('"', fname, "\" is not a JLD2 file")))
         else
-            @warn("This file was written with an older version of JLD2. Attempting to load data.", maxlog=1)
+            #@warn("This file was written with an older version of JLD2. Attempting to load data.", maxlog=1)
             return
         end
     end


### PR DESCRIPTION
This PR changes the (magic) header bytes to something that is less similar to what JLD uses.

Files with the old header will still be read but a commented out warning message has already been added.
This will become relevant when/if we make changes that break backwards compatibility.

Tests for this will fail since the tests rely on FileIO that does not recognize the new magic bytes yet.

closes #211