### PR TITLE
Remove FileIO dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ matrix:
 notifications:
   email: false
 
+install:
+  - julia -e 'using Pkg; Pkg.add("FileIO")'
+
 # script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("JLD2"); Pkg.test("JLD2"; coverage=true)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ notifications:
 #  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("JLD2"); Pkg.test("JLD2"; coverage=true)'
 
 after_success:
-  - julia -e 'cd(Pkg.dir("JLD2")); Pkg.add("Coverage"); Pkg.checkout("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg; cd(Pkg.dir("JLD2")); Pkg.add("Coverage"); Pkg.checkout("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ notifications:
 #  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("JLD2"); Pkg.test("JLD2"; coverage=true)'
 
 after_success:
-  - julia -e 'using Pkg; cd(Pkg.dir("JLD2")); Pkg.add("Coverage"); Pkg.checkout("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg; cd(Pkg.dir("JLD2")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ notifications:
 #  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("JLD2"); Pkg.test("JLD2"; coverage=true)'
 
 after_success:
-  - julia -e 'using Pkg; cd(Pkg.dir("JLD2")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ matrix:
 notifications:
   email: false
 
-install:
-  - julia -e 'using Pkg; Pkg.add("FileIO")'
 
 # script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ MacroTools = "0.5"
 julia = "0.7, 1"
 
 [extras]
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 LIBSVM = "b1bec4e5-fd48-53fe-b0cb-9723c09d164b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -28,4 +28,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LIBSVM", "LinearAlgebra", "Printf", "RDatasets", "Random", "Test"]
+test = ["FileIO", "LIBSVM", "LinearAlgebra", "Printf", "RDatasets", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,21 +5,17 @@ version = "0.1.14"
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 CodecZlib = "0.5, 0.6, 0.7"
-DataFrames = "0.19.4"
 DataStructures = "0.17"
-FileIO = "1"
-LIBSVM = "0.3"
 MacroTools = "0.5"
-RDatasets = "0.6"
 julia = "0.7, 1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Travis Build Status](https://travis-ci.org/JuliaIO/JLD2.jl.svg?branch=master)](https://travis-ci.org/JuliaIO/JLD2.jl)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/9wk39naux5dhwhen?svg=true)](https://ci.appveyor.com/project/simonster/jld2-jl)
-[![codecov.io](http://codecov.io/github/JuliaIO/JLD2.jl/coverage.svg?branch=master)](http://codecov.io/github/simonster/JLD2.jl?branch=master)
+[![codecov.io](http://codecov.io/github/JuliaIO/JLD2.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaIO/JLD2.jl?branch=master)
 
 JLD2 saves and loads Julia data structures in a format comprising a subset of HDF5, without any dependency on the HDF5 C library. It typically outperforms [the previous JLD package](https://github.com/JuliaIO/JLD.jl) (sometimes by multiple orders of magnitude) and often outperforms Julia's built-in serializer. While other HDF5 implementations supporting HDF5 File Format Specification Version 3.0 (i.e. libhdf5 1.10 or later) should be able to read the files that JLD2 produces, JLD2 is likely to be incapable of reading files created or modified by other HDF5 implementations. JLD2 does not aim to be backwards or forwards compatible with the previous JLD package.
 

--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -1,5 +1,5 @@
 module JLD2
-using DataStructures, CodecZlib, FileIO
+using DataStructures, CodecZlib, Requires
 import Base.sizeof
 using MacroTools
 using Printf
@@ -416,5 +416,9 @@ include("data.jl")
 include("dataio.jl")
 include("loadsave.jl")
 include("stdlib.jl")
+
+function __init__()
+    @require FileIO="5789e2e9-d7fb-5bc7-8068-2c6fae9b9549" include("fileio.jl")    
+end
 
 end # module

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -1,0 +1,56 @@
+@info "loading FileIO interface"
+
+using .FileIO
+
+# Save all the key-value pairs in the dict as top-level variables of the JLD
+function save(f::File{format"JLD2"}, dict::AbstractDict; kwargs...)
+    jldopen(FileIO.filename(f), "w"; kwargs...) do file
+        wsession = JLDWriteSession()
+        for (k,v) in dict
+            if !isa(k, AbstractString)
+                throw(ArgumentError("keys must be strings (the names of variables), got $k"))
+            end
+            write(file, String(k), v, wsession)
+        end
+    end
+end
+
+# Or the names and values may be specified as alternating pairs
+function save(f::File{format"JLD2"}, name::AbstractString, value, pairs...; kwargs...)
+    if isodd(length(pairs)) || !isa(pairs[1:2:end], Tuple{Vararg{AbstractString}})
+        throw(ArgumentError("arguments must be in name-value pairs"))
+    end
+    jldopen(FileIO.filename(f), "w"; kwargs...) do file
+        wsession = JLDWriteSession()
+        write(file, String(name), value, wsession)
+        for i = 1:2:length(pairs)
+            write(file, String(pairs[i]), pairs[i+1], wsession)
+        end
+    end
+end
+
+save(f::File{format"JLD2"}, value...; kwargs...) = error("must supply a name for each variable")
+
+
+# load with just a filename returns a dictionary containing all the variables
+function load(f::File{format"JLD2"}; kwargs...)
+    jldopen(FileIO.filename(f), "r"; kwargs...) do file
+        loadtodict!(Dict{String,Any}(), file)
+    end
+end
+
+# When called with explicitly requested variable names, return each one
+function load(f::File{format"JLD2"}, varname::AbstractString; kwargs...)
+    jldopen(FileIO.filename(f), "r"; kwargs...) do file
+        read(file, varname)
+    end
+end
+
+load(f::File{format"JLD2"}, varnames::AbstractString...; kwargs...) =
+    load(f, varnames; kwargs...)
+
+function load(f::File{format"JLD2"}, varnames::Tuple{Vararg{AbstractString}}; kwargs...)
+    jldopen(FileIO.filename(f), "r"; kwargs...) do file
+        map((var)->read(file, var), varnames)
+    end
+end

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -1,5 +1,3 @@
-@info "loading FileIO interface"
-
 using .FileIO
 
 # Save all the key-value pairs in the dict as top-level variables of the JLD


### PR DESCRIPTION
I moved all FileIO-dependent function to a new file and wrapped it in an `@require`.
I left `loadtodict!` in `loadsave.jl` because it doesn't depend on FileIO, but it's not used outside the FileIO API, so we could also move it to the new file.

closes #204