### PR TITLE
Implement backend fallback behaviour

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -183,10 +183,10 @@ h5offset(f::JLDFile, x::Int64) = RelOffset(x - FILE_HEADER_LENGTH)
 # File
 #
 
-openfile(::Type{IOStream}, fname, wr, create, truncate, fallback::Nothing) =
+openfile(::Type{IOStream}, fname, wr, create, truncate, fallback::Nothing = nothing) =
     open(fname, read = true, write = wr, create = create,
          truncate = truncate, append = false)
-openfile(::Type{MmapIO}, fname, wr, create, truncate, fallback::Nothing) =
+openfile(::Type{MmapIO}, fname, wr, create, truncate, fallback::Nothing = nothing) =
     MmapIO(fname, wr, create, truncate)
 
 function openfile(T::Type, fname, wr, create, truncate, fallback::Type)

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -8,7 +8,10 @@ fn = joinpath(mktempdir(), "test.jld2")
 #  fallback specified → switch to fallback
 fh = JLD2.openfile(ArgumentError, fn, true, true, false, JLD2.MmapIO)
 @test fh isa JLD2.MmapIO
-close(fh)
+# To avoid an mmap error on mac, have to write something to the stream before closing
+JLD2.ensureroom(fh, 8)
+write(fh, 42)
+JLD2.truncate_and_close(fh, 8)
 
 # test file path checking
 Sys.isunix() && @test_throws ArgumentError jldopen("/dev/null", "r")

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -184,7 +184,7 @@ end
 
 # Issue #183
 jfn, _ = mktemp()
-@test_throws SystemError jldopen(jfn, "r")
+@test_throws SystemError jldopen(jfn, "r", fallback = nothing)
 
 # PR #206 Allow serialization of UnionAll in Union
 struct UA1{T}; x::T; end

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -2,6 +2,18 @@ using JLD2, FileIO, Test
 
 fn = joinpath(mktempdir(), "test.jld2")
 
+# test iotype fallback
+#  no fallback specified → throw method error
+@test_throws MethodError JLD2.openfile(ArgumentError, fn, true, true, false, nothing)
+#  fallback specified → switch to fallback
+fh = JLD2.openfile(ArgumentError, fn, true, true, false, JLD2.MmapIO)
+@test fh isa JLD2.MmapIO
+close(fh)
+
+# test file path checking
+Sys.isunix() && @test_throws ArgumentError jldopen("/dev/null", "r")
+@test_throws ArgumentError jldopen(dirname(fn), "r")
+
 # Test load macros
 jldopen(fn, "w") do f
     write(f, "loadmacrotestvar1", ['a', 'b', 'c'])


### PR DESCRIPTION
as discussed in #201.
Also ensures that only paths that either refer to a regular file or do not refer to any file system entity at all are passed to `openfile`. This prevents the weird error messages when trying to mmap directories (or even devices, although I haven't tried that yet).

I haven't made sure that the fallback option is accessible from all APIs yet, and I'm going to try to add a few tests as well.