### PR TITLE
Make read and write threadsafe

### DIFF
--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -119,7 +119,7 @@ function read_attr_data(f::JLDFile, attr::ReadAttribute, expected_datatype::H5Da
         dt = read(io, typeof(expected_datatype))
         if dt == expected_datatype
             seek(f.io, attr.data_offset)
-            read_dataspace = (attr.dataspace, NULL_REFERENCE, -1, 0)
+            read_dataspace = (attr.dataspace, NULL_REFERENCE, -1, UInt16(0))
             return read_data(f, rr, read_dataspace)
         end
     end

--- a/src/stdlib.jl
+++ b/src/stdlib.jl
@@ -4,6 +4,7 @@ using Pkg
 using UUIDs
 
 const STDLIB = Ref{Dict{UUID, String}}()
+const STDLIB_LOCK = ReentrantLock()
 
 function projectfile_path(env_path::String; strict=false)
     for name in Base.project_names
@@ -31,10 +32,12 @@ function load_stdlib()
 end
 
 function stdlib()
-    if !isassigned(STDLIB)
-        STDLIB[] = load_stdlib()
+    lock(STDLIB_LOCK) do
+        if !isassigned(STDLIB)
+            STDLIB[] = load_stdlib()
+        end
+        stdlib = deepcopy(STDLIB[])
     end
-    return deepcopy(STDLIB[])
 end
 
 function stdlibmodules(m::Module)::Vector{Module}


### PR DESCRIPTION
This PR aims to make reading and writing independent files on multiple threads possible
by removing unnecessary global states and protecting necessary ones with `ReentrantLock`s.

Somehow this should have tests..