### PR TITLE
Make macro use try catch finally instead of do syntax

### DIFF
--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -59,9 +59,16 @@ macro save(filename, vars...)
     end
     if !isempty(fields)
         return quote
-            jldopen($(esc(filename)), "w"; $(Expr(:tuple,options...))...) do f
+            let
+                f = jldopen($(esc(filename)), "w"; $(Expr(:tuple,options...))...)
                 wsession = JLDWriteSession()
-                $(Expr(:block, fields...))
+                try
+                    $(Expr(:block, fields...))
+                catch e
+                    rethrow(e)
+                finally
+                    close(f)
+                end
             end
         end
     else


### PR DESCRIPTION
This makes the `@save` macro translate to something that does not have to compile an anonymous function every time.
Before: 
```julia
julia> @time @save "test.jld2" a
  0.050988 seconds (7.13 k allocations: 389.079 KiB)
```
After:
```julia
julia> @time @save "test.jld2" a
  0.002866 seconds (85 allocations: 8.531 KiB)
```