### PR TITLE
Fixes a bug where read would just read up to sizeof(T)

### DIFF
--- a/src/bufferedio.jl
+++ b/src/bufferedio.jl
@@ -100,7 +100,7 @@ function Base.read(io::BufferedReader, ::Type{T}, n::Int) where T
     buffer = io.buffer
     n = sizeof(T) * n
     if length(buffer) - position < n
-        readmore!(io, sizeof(T))
+        readmore!(io, n)
     end
     io.position[] = position + n
     arr = Vector{T}(undef, n)

--- a/src/bufferedio.jl
+++ b/src/bufferedio.jl
@@ -98,11 +98,11 @@ end
 function Base.read(io::BufferedReader, ::Type{T}, n::Int) where T
     position = io.position[]
     buffer = io.buffer
-    n = sizeof(T) * n
-    if length(buffer) - position < n
-        readmore!(io, n)
+    m = sizeof(T) * n
+    if length(buffer) - position < m
+        readmore!(io, m)
     end
-    io.position[] = position + n
+    io.position[] = position + m
     arr = Vector{T}(undef, n)
     unsafe_copyto!(pointer(arr), Ptr{T}(pointer(buffer, position+1)), n)
     arr

--- a/test/bufferedreader.jl
+++ b/test/bufferedreader.jl
@@ -1,0 +1,21 @@
+using JLD2
+using Test
+using Random
+
+tdir = tempdir()
+
+@testset "BufferedReader" begin
+    cd(tdir) do
+        a = randn(100)
+        open("testfile.1", "w") do ff
+            write(ff, a) 
+        end
+        b = open("testfile.1", "r") do ff
+            br = JLD2.BufferedReader(ff)
+            b = read(br, Float64, 100)
+        end
+        @test a ≈ b
+        rm("testfile.1")
+    end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using JLD2, FileIO
 using Test
 
+include("bufferedreader.jl")
 include("lookup3.jl")
 include("internal.jl")
 include("rw.jl")


### PR DESCRIPTION
I came across this bug when looking into why all dataset/group names only contained the first character of the name. It turned out that it was always just reading the number of bytes corresponding to the size of the type, not the request number of bytes.