### PR TITLE
Make sure to not wrap unknown type again

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD2"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/data.jl
+++ b/src/data.jl
@@ -966,9 +966,9 @@ function jlconvert(rr::ReadRepresentation{T,DataTypeODR()},
     hasparams = !isempty(params)
     mypath = String(jlconvert(ReadRepresentation{UInt8,Vlen{UInt8}}(), f, ptr, NULL_REFERENCE))
     m = _resolve_type(rr, f, ptr, header_offset, mypath, hasparams, hasparams ? params : nothing)
-
+    m isa UnknownType && return m
+    
     if hasparams
-        unknown_params && return UnknownType(m, params)
         try
             m = m{params...}
         catch e


### PR DESCRIPTION
This is a bug that must have been introduced while improving the moduley/type resolution.

With a simple one-line change we make sure that types do not accidentally
get wrapped in `UnknownType` twice.

closes #240 
and likely also resolves #190 