### PR TITLE
Fix hasdata when types occur multiple times

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD2"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/data.jl
+++ b/src/data.jl
@@ -62,7 +62,7 @@ end
 function hasdata(T::DataType, encounteredtypes=DataType[])
     isempty(T.types) && T.size != 0 && return true
     for ty in T.types
-        hasfielddata(writeas(ty), encounteredtypes) && return true
+        hasfielddata(writeas(ty), copy(encounteredtypes)) && return true
     end
     false
 end

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -239,3 +239,14 @@ struct UA2{T}; y::T; end
     @test u2 == U2[1, [2.0], 3, ["4"]]
     @test u3 == U3[UA1(1), UA2(2.0), 3, UA1("4")]
 end
+
+
+
+# Test for Issue #247
+@testset "Tuple of Empty Structs" begin
+    fn = joinpath(mktempdir(), "test.jld2")
+    @save fn tup=(EmptyImmutable(), EmptyImmutable())
+    @load fn tup
+
+    @test tup == (EmptyImmutable(), EmptyImmutable())
+end


### PR DESCRIPTION
When reworking `hasdata` in #196 I forgot that structs can have multiple fields with the same type and introduced a bug.

closes #247 