### PR TITLE
Draft: add customserialization for Ntuples

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -1138,6 +1138,12 @@ function rconvert(::Type{T}, x::Vector{Pair{K,V}}) where {T<:AbstractDict,K,V}
     d
 end
 
+## NTuples
+
+writeas(::Type{NTuple{N,T}}) where {N,T} = Vector{T}
+wconvert(::Type{Vector{T}}, x::NTuple{N,T}) where {N,T} = reduce(vcat, x)
+rconvert(::Type{NTuple{N,T}}, x::Vector{T}) where {N,T} = NTuple{N,T}(x)
+
 ## Type reconstruction
 
 module ReconstructedTypes end

--- a/src/data.jl
+++ b/src/data.jl
@@ -1141,6 +1141,7 @@ end
 ## NTuples
 
 writeas(::Type{NTuple{N,T}}) where {N,T} = Vector{T}
+writeas(::Type{Tuple{}}) = Tuple{}
 wconvert(::Type{Vector{T}}, x::NTuple{N,T}) where {N,T} = reduce(vcat, x)
 rconvert(::Type{NTuple{N,T}}, x::Vector{T}) where {N,T} = NTuple{N,T}(x)
 


### PR DESCRIPTION
This PR adds a custom serialization for `NTuples` to be converted to vectors before writing.

This has the advantage of generating smaller files when long `NTuple`s are being stored.

```
using JLD2
@save "test2.jld2" a=[1,2,3] b=[1,2,3,4,5] c=rand(1000)
# Yields 26k file size


@save "test.jld2" a=(1,2,3) b=(1,2,3,4,5) c=NTuple{1000,Float64}(rand(1000))
# Currently 47k
# Reduced to 26k with custom serialization
```

The reduction is due to the fact that `Tuple`s are serialized as a H5Compound datatype containing a list of fields.
This type description growths linearly with the number of fields. (Listing the type for every field..)
The double type description for custom serialization is more compact.


I'm not sure this PR is needed or even useful since I always thought that very long tuples are not good programming practice 
but I'm open for discussion.

(potentially solves #263 )