### PR TITLE
cache the correct object

### DIFF
--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -333,8 +333,10 @@ function read_array(f::JLDFile, dataspace::ReadDataspace,
                     filter_id::UInt16, header_offset::RelOffset,
                     attributes::Union{Vector{ReadAttribute},Nothing})
     rrv = ReadRepresentation{UInt8,odr(UInt8)}()
-    v = read_array(f, dataspace, rrv, data_length, filter_id, header_offset, attributes)
-    String(v)
+    v = read_array(f, dataspace, rrv, data_length, filter_id, NULL_REFERENCE, attributes)
+    s = String(v)
+    header_offset !== NULL_REFERENCE && (f.jloffset[header_offset] = WeakRef(s))
+    s
 end
 
 function payload_size_without_storage_message(dataspace::WriteDataspace, datatype::H5Datatype)

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -249,7 +249,7 @@ end
     @load fn tup
 
     @test tup == (EmptyImmutable(), EmptyImmutable())
-    
+
     # Test for Recursively Empty struct
     @save fn tup=(EmptyII(EmptyImmutable()), EmptyImmutable())
     @load fn tup
@@ -257,3 +257,18 @@ end
     @test tup == (EmptyII(EmptyImmutable()), EmptyImmutable())
 end
 
+
+
+# Test for Issue #269
+@testset "Repeatedly load String" begin
+    fn = joinpath(mktempdir(), "test.jld2")
+    s = "Lorem Ipsum"
+    @save fn s="Lorem Ipsum"
+    f = jldopen(fn, "r")
+
+    @test s == f["s"]
+    @test s == f["s"]
+    @test s == f["s"]
+    @test s == f["s"]
+    @test s == f["s"]
+end


### PR DESCRIPTION
Previously the underlying UInt8 Array used to create a loaded String was cached 
and potentially returned when accessed again.
This PR instead caches the string.

closes #269