### PR TITLE
use contiguousstoragemessage for large (scalar) data

### DIFF
--- a/src/backwards_compatibility.jl
+++ b/src/backwards_compatibility.jl
@@ -11,3 +11,14 @@ end
 constructrr(::JLDFile, ::Type{T}, dt::VariableLengthDatatype, ::Vector{ReadAttribute}) where {T<:Union} =
     dt == LEGACY_H5TYPE_UNION ? (ReadRepresentation{Union,Vlen{DataTypeODR()}}(), true) :
                          throw(UnsupportedFeatureException())
+
+# The following definition is needed to correctly load Strings written
+# with JLD2 with versions v0.1.12 - v0.3.1
+function read_array(f::JLDFile, dataspace::ReadDataspace,
+                    rr::FixedLengthString{String}, data_length::Int,
+                    filter_id::UInt16, header_offset::RelOffset,
+                    attributes::Union{Vector{ReadAttribute},Nothing})
+    rrv = ReadRepresentation{UInt8,odr(UInt8)}()
+    v = read_array(f, dataspace, rrv, data_length, filter_id, NULL_REFERENCE, attributes)
+    String(v)
+end

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -441,14 +441,12 @@ function write_dataset(f::JLDFile, dataspace::WriteDataspace, datatype::H5Dataty
             write_data(cio, f, data, odr, datamode(odr), wsession)
         end
         write(io, end_checksum(cio))
-    elseif layout_class == LC_CONTIGUOUS_STORAGE
+    else
         write(cio, ContiguousStorageMessage(datasz, h5offset(f, f.end_of_data)))
         write(io, end_checksum(cio))
 
         f.end_of_data += datasz
         write_data(io, f, data, odr, datamode(odr), wsession)
-    else
-        throw(Error("Storage Message Error"))
     end
 
     h5offset(f, header_offset)


### PR DESCRIPTION
This solves #269 and supercedes #270 by fixing a bug introduced in #152  .

When a scalar dataset such as a string exceeds `typemax(UInt16)` it no longer fits the
`CompactStorageMessage`. We now switch to `ContiguousStorageMessage` in that case.