### PR TITLE
use standard h5 type for bools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD2"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/data.jl
+++ b/src/data.jl
@@ -600,14 +600,14 @@ for T in Base.uniontypes(SignedTypes)
 end
 for T in Base.uniontypes(UnsignedTypes)
     @eval h5fieldtype(::JLDFile, ::$T, ::$T, ::Initialized) =
-    FixedPointDatatype($(T.parameters[1].size), false)
+        FixedPointDatatype($(T.parameters[1].size), false)
 end
 
 
 function jltype(f::JLDFile, dt::FixedPointDatatype)
     signed = dt.bitfield1 == 0x08 ? true : dt.bitfield1 == 0x00 ? false : throw(UnsupportedFeatureException())
     ((dt.bitfield2 == 0x00) & (dt.bitfield3 == 0x00) & (dt.bitoffset == 0) & (dt.bitprecision == dt.size*8)) ||
-    throw(UnsupportedFeatureException())
+        throw(UnsupportedFeatureException())
     if dt.size == 8
         return signed ? ReadRepresentation{Int64,Int64}() : ReadRepresentation{UInt64,UInt64}()
     elseif dt.size == 1

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -78,6 +78,8 @@ macro read_datatype(io, datatype_class, datatype, then)
             $(replace_expr(then, datatype, :(read($io, CompoundDatatype))))
         elseif $datatype_class == DT_VARIABLE_LENGTH
             $(replace_expr(then, datatype, :(read($io, VariableLengthDatatype))))
+        elseif $datatype_class == DT_BITFIELD
+            $(replace_expr(then, datatype, :(read($io, BitFieldDatatype))))
         else
             throw(UnsupportedFeatureException())
         end
@@ -96,6 +98,20 @@ end
 define_packed(FixedPointDatatype)
 FixedPointDatatype(size::Integer, signed::Bool) =
     FixedPointDatatype(DT_FIXED_POINT, ifelse(signed, 0x08, 0x00), 0x00, 0x00, size, 0, 8*size)
+
+struct BitFieldDatatype <: H5Datatype
+    class::UInt8
+    bitfield1::UInt8
+    bitfield2::UInt8
+    bitfield3::UInt8
+    size::UInt32
+    bitoffset::UInt16
+    bitprecision::UInt16
+end
+define_packed(BitFieldDatatype)
+BitFieldDatatype(size) =
+    BitFieldDatatype(DT_BITFIELD, 0x00, 0x00, 0x00, size, 0, 8*size)
+
 
 struct FloatingPointDatatype <: H5Datatype
     class::UInt8


### PR DESCRIPTION
Currently `Bool`s are encoded as an opaque datatype which is different from what
HDF5.jl does and different from what seems logical.

Currently:
```
julia> jldopen("test2.jld2", "w") do f; f["b"] = true; f["false"]=false;end;

 ~> h5dump test2.jld2
HDF5 "test2.jld2" {
GROUP "/" {
   GROUP "_types" {
      DATATYPE "00000001" H5T_COMPOUND {
         H5T_STRING {
            STRSIZE H5T_VARIABLE;
            STRPAD H5T_STR_NULLPAD;
            CSET H5T_CSET_UTF8;
            CTYPE H5T_C_S1;
         } "name";
         H5T_VLEN { H5T_REFERENCE { H5T_STD_REF_OBJECT }} "parameters";
      }
         ATTRIBUTE "julia_type" {
            DATATYPE  "/_types/00000001"
            DATASPACE  SCALAR
            DATA {
            (0): {
                  "Core.DataType",
                  ()
               }
            }
         }
      DATATYPE "00000002" H5T_OPAQUE {
         OPAQUE_TAG "";
      };
         ATTRIBUTE "julia_type" {
            DATATYPE  "/_types/00000001"
            DATASPACE  SCALAR
            DATA {
            (0): {
                  "Core.Bool",
                  ()
               }
            }
         }
   }
   DATASET "b" {
      DATATYPE  "/_types/00000002"
      DATASPACE  SCALAR
      DATA {
      (0): 0x01
      }
   }
   DATASET "false" {
      DATATYPE  "/_types/00000002"
      DATASPACE  SCALAR
      DATA {
      (0): 0x00
      }
   }
}
}
```

Whereas with this PR:
```
julia> jldopen("test2.jld2", "w") do f; f["b"] = true; f["false"]=false;end;

~> h5dump test2.jld2
HDF5 "test2.jld2" {
GROUP "/" {
   DATASET "b" {
      DATATYPE  H5T_STD_B8LE
      DATASPACE  SCALAR
      DATA {
      (0): 0x01
      }
   }
   DATASET "false" {
      DATATYPE  H5T_STD_B8LE
      DATASPACE  SCALAR
      DATA {
      (0): 0x00
      }
   }
}
}

```
Old files with the current encoding will still be readable.