### PR TITLE
Allow Pointers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD2"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/docs/src/hdf5compat.md
+++ b/docs/src/hdf5compat.md
@@ -127,6 +127,8 @@ it is shown here as it serves as a good example for usage of that feature.
 
 ```julia
    writeas(::Type{<:Ptr}) = Nothing
-   wconvert(::Type{Nothing}, ::Ptr) = nothing
    rconvert(::Type{Ptr{T}}, ::Nothing) where {T} = Ptr{T}()
 ```
+
+Usually one would also have to define a method for `wconvert`. However, in this 
+case JLD2 figures out that ne explicit conversion is needed to construct `nothing`.

--- a/docs/src/hdf5compat.md
+++ b/docs/src/hdf5compat.md
@@ -101,10 +101,32 @@ We can see that the file contains two things at top-level. There is a dataset `"
 (that is what we wanted to store) and there is a group `_types` which is where
 all the necessary type information is stored.
 
-You can see that JLD2 _commited_ two compound datatypes. The first one is `Core.Datatype`
+You can see that JLD2 _committed_ two compound datatypes. The first one is `Core.Datatype`
 which at first seems rather unintuitive. It is needed to tell HDF5 what a serialized 
 julia datatype looks like (a name and a list of parameters).
 
 Below that is the definition of `MyCustomStruct` with two fields 
 `H5T_STD_I64LE "x"` and `H5T_IEEE_F64LE "y"` defining the integer field `x` and
 the float field `y`.
+
+## A note on pointers
+
+In the julia programming language pointers `Ptr` are not needed very often. However,
+when binary dependencies come into play and memory is passed back and forth,
+pointers do become relevant. Pointers are addresses to locations in memory and
+thus lose their meaning after a program has terminated.
+
+In principle, there is little point in storing a pointer to a file but
+in order to allow for a more seamless experience JLD2 will, similar to `Base.Serialization`
+silently accept pointers. This is useful when storing large structures such as
+a `DifferentialEquations.jl` solution object that might contain a pointer somewhere.
+Upon deserialization any pointer fields are instantiated as null pointers.
+
+This is done with just three lines of code utilizing the custom serialization logic and 
+it is shown here as it serves as a good example for usage of that feature.
+
+```julia
+   writeas(::Type{<:Ptr}) = Nothing
+   wconvert(::Type{Nothing}, ::Ptr) = nothing
+   rconvert(::Type{Ptr{T}}, ::Nothing) where {T} = Ptr{T}()
+```

--- a/src/data.jl
+++ b/src/data.jl
@@ -1090,7 +1090,7 @@ end
 # Due to popular demand and in particular to not error on serializing complex structures
 # that contain non-essential pointers this has been changed to instead 
 # return null pointers.
-writeas(::Type{<:Ptr}) = Nothing
+writeas(::Type{Ptr{T}}) where {T} = Nothing
 wconvert(::Type{Nothing}, ::Ptr) = nothing
 rconvert(::Type{Ptr{T}}, ::Nothing) where {T} = Ptr{T}()
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -1092,7 +1092,7 @@ end
 # return null pointers.
 writeas(::Type{Ptr{T}}) where {T} = Nothing
 wconvert(::Type{Nothing}, ::Ptr) = nothing
-rconvert(::Type{Ptr{T}}, ::Nothing) where {T} = Ptr{T}()
+rconvert(::Type{Ptr{T}}, ::Nothing) where {T} = Ptr{T}(0)
 
 ## Arrays
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -1091,7 +1091,6 @@ end
 # that contain non-essential pointers this has been changed to instead 
 # return null pointers.
 writeas(::Type{Ptr{T}}) where {T} = Nothing
-wconvert(::Type{Nothing}, ::Ptr) = nothing
 rconvert(::Type{Ptr{T}}, ::Nothing) where {T} = Ptr{T}(0)
 
 ## Arrays

--- a/src/data.jl
+++ b/src/data.jl
@@ -1086,11 +1086,13 @@ function h5convert!(out::Pointers,
 end
 
 ## Pointers
-
-struct PointerException <: Exception; end
-Base.showerror(io::IO, ::PointerException) = print(io, "cannot write a pointer to JLD file")
-h5fieldtype(::JLDFile, ::Type{T}, ::Type, ::Initialized) where {T<:Ptr} = throw(PointerException())
-h5type(::JLDFile, ::Type{T}, @nospecialize arg) where {T<:Ptr} = throw(PointerException())
+# Previously it was disallowed to serialize pointers.
+# Due to popular demand and in particular to not error on serializing complex structures
+# that contain non-essential pointers this has been changed to instead 
+# return null pointers.
+writeas(::Type{<:Ptr}) = Nothing
+wconvert(::Type{Nothing}, ::Ptr) = nothing
+rconvert(::Type{Ptr{T}}, ::Nothing) where {T} = Ptr{T}()
 
 ## Arrays
 

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -264,11 +264,11 @@ end
     @save fn ptr=pointer(zeros(5))
     @load fn ptr
 
-    @test ptr == Ptr{Float64}()
+    @test ptr == Ptr{Float64}(0)
     
     # Test for pointer inside structure
     @save fn tup=(; ptr = pointer(zeros(5)))
     @load fn tup
 
-    @test tup == (; ptr = Ptr{Float64}())
+    @test tup == (; ptr = Ptr{Float64}(0))
 end

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -257,3 +257,18 @@ end
     @test tup == (EmptyII(EmptyImmutable()), EmptyImmutable())
 end
 
+
+# Test for storing pointers
+@testset "Pointer Serialization" begin
+    fn = joinpath(mktempdir(), "test.jld2")
+    @save fn ptr=pointer(zeros(5))
+    @load fn ptr
+
+    @test ptr == Ptr{Float64}()
+    
+    # Test for pointer inside structure
+    @save fn tup=(; ptr = pointer(zeros(5)))
+    @load fn tup
+
+    @test tup == (; ptr = Ptr{Float64}())
+end

--- a/test/rw.jl
+++ b/test/rw.jl
@@ -82,11 +82,6 @@ ms_undef = MyStruct(0)
 version_info = Base.GIT_VERSION_INFO
 # Immutable type:
 rng = 1:5
-# Type with a pointer field (#84)
-struct ObjWithPointer
-    a::Ptr{Cvoid}
-end
-objwithpointer = ObjWithPointer(0)
 # Custom BitsType (#99)
 primitive type MyBT 64 end
 bt = reinterpret(MyBT, Int64(55))
@@ -405,7 +400,6 @@ for ioty in [JLD2.MmapIO, IOStream], compress in [false, true]
     @write fid arr_undef
     @write fid arr_undefs
     @write fid ms_undef
-    @test_throws JLD2.PointerException @write fid objwithpointer
     @write fid bt
     @write fid btarray
     @write fid sa_asc


### PR DESCRIPTION
With this PR JLD2 will no longer error when attempting to store pointers.
Matching the behaviour of `Base.Serialization`, loaded pointers will always be null.

closes #251
also solves #128