### PR TITLE
WIP: Allow custom expected group size

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -116,18 +116,26 @@ mutable struct Group{T}
     last_chunk_start_offset::Int64
     continuation_message_goes_here::Int64
     last_chunk_checksum_offset::Int64
+    next_link_offset::Int64
+    est_num_entries::Int64
+    est_link_name_len::Int64
     unwritten_links::OrderedDict{String,RelOffset}
     unwritten_child_groups::OrderedDict{String,Group}
     written_links::OrderedDict{String,RelOffset}
 
-    Group{T}(f) where T =
-        new(f, -1, -1, -1, OrderedDict{String,RelOffset}(), OrderedDict{String,Group}())
+    Group{T}(f; est_num_entries::Int=4, est_link_name_len::Int=8) where T =
+        new(f, -1, -1, -1, -1, est_num_entries, est_link_name_len,
+        OrderedDict{String,RelOffset}(), OrderedDict{String,Group}())
 
     Group{T}(f, last_chunk_start_offset, continuation_message_goes_here,
-             last_chunk_checksum_offset, unwritten_links, unwritten_child_groups,
+             last_chunk_checksum_offset, next_link_offset, 
+             est_num_entries, est_link_name_len,
+             unwritten_links, unwritten_child_groups,
              written_links) where T =
         new(f, last_chunk_start_offset, continuation_message_goes_here,
-            last_chunk_checksum_offset, unwritten_links, unwritten_child_groups,
+            last_chunk_checksum_offset, next_link_offset,
+            est_num_entries, est_link_name_len,
+            unwritten_links, unwritten_child_groups,
             written_links)
 end
 


### PR DESCRIPTION
Adds two additional keyword arguments to constructors of `Group` ,
namely `est_num_entries == 4` and `est_link_name_len == 8` to allow 
tune how much space should be left at the end of a group table
for future appending.

(Also implements appending when there is space left)
These two settings are stored inside group metadata and are recovered when loading a file.
They are also used to compute how much additional space should be allocated when the existing space runs out.

`est_num_entries` specifies how many entries the group is expected to contain
`est_link_name_len` allows to further tune that by specifying the expected average number of bytes per dataset `name`

