### PR TITLE
WIP: symbol api

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -343,22 +343,27 @@ function prewrite(f::JLDFile)
     f.written = true
 end
 
-Base.read(f::JLDFile, name::AbstractString) = f.root_group[name]
-Base.write(f::JLDFile, name::AbstractString, obj, wsession::JLDWriteSession=JLDWriteSession()) =
+const StringOrSymbol = Union{Symbol, AbstractString}
+
+stringify(name::Symbol) = "__"*string(name)
+stringify(name::AbstractString) = string(name)
+
+Base.read(f::JLDFile, name::StringOrSymbol) = f.root_group[name]
+Base.write(f::JLDFile, name::StringOrSymbol, obj, wsession::JLDWriteSession=JLDWriteSession()) =
     write(f.root_group, name, obj, wsession)
 
-Base.getindex(f::JLDFile, name::AbstractString) = f.root_group[name]
-Base.setindex!(f::JLDFile, obj, name::AbstractString) = (f.root_group[name] = obj; f)
-Base.haskey(f::JLDFile, name::AbstractString) = haskey(f.root_group, name)
+Base.getindex(f::JLDFile, name::StringOrSymbol) = f.root_group[name]
+Base.setindex!(f::JLDFile, obj, name::StringOrSymbol) = (f.root_group[name] = obj; f)
+Base.haskey(f::JLDFile, name::StringOrSymbol) = haskey(f.root_group, name)
 Base.isempty(f::JLDFile) = isempty(f.root_group)
 Base.keys(f::JLDFile) = filter!(x->x != "_types", keys(f.root_group))
-Base.get(default::Function, f::Union{JLDFile, Group}, name::AbstractString) =
+Base.get(default::Function, f::Union{JLDFile, Group}, name::StringOrSymbol) =
     haskey(f, name) ? f[name] : default()
-Base.get(f::Union{JLDFile, Group}, name::AbstractString, default) =
+Base.get(f::Union{JLDFile, Group}, name::StringOrSymbol, default) =
     haskey(f, name) ? f[name] : default
-Base.get!(f::Union{JLDFile, Group}, name::AbstractString, default) =
+Base.get!(f::Union{JLDFile, Group}, name::StringOrSymbol, default) =
     get!(() -> default, f, name)
-function Base.get!(default::Function, f::Union{JLDFile, Group}, name::AbstractString)
+function Base.get!(default::Function, f::Union{JLDFile, Group}, name::StringOrSymbol)
     if haskey(f, name)
         return f[name]
     else

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -5,24 +5,24 @@ function save(f::File{format"JLD2"}, dict::AbstractDict; kwargs...)
     jldopen(FileIO.filename(f), "w"; kwargs...) do file
         wsession = JLDWriteSession()
         for (k,v) in dict
-            if !isa(k, AbstractString)
+            if !isa(k, StringOrSymbol)
                 throw(ArgumentError("keys must be strings (the names of variables), got $k"))
             end
-            write(file, String(k), v, wsession)
+            write(file, k, v, wsession)
         end
     end
 end
 
 # Or the names and values may be specified as alternating pairs
-function save(f::File{format"JLD2"}, name::AbstractString, value, pairs...; kwargs...)
-    if isodd(length(pairs)) || !isa(pairs[1:2:end], Tuple{Vararg{AbstractString}})
+function save(f::File{format"JLD2"}, name::StringOrSymbol, value, pairs...; kwargs...)
+    if isodd(length(pairs)) || !isa(pairs[1:2:end], Tuple{Vararg{StringOrSymbol}})
         throw(ArgumentError("arguments must be in name-value pairs"))
     end
     jldopen(FileIO.filename(f), "w"; kwargs...) do file
         wsession = JLDWriteSession()
-        write(file, String(name), value, wsession)
+        write(file, name, value, wsession)
         for i = 1:2:length(pairs)
-            write(file, String(pairs[i]), pairs[i+1], wsession)
+            write(file, pairs[i], pairs[i+1], wsession)
         end
     end
 end
@@ -33,21 +33,21 @@ save(f::File{format"JLD2"}, value...; kwargs...) = error("must supply a name for
 # load with just a filename returns a dictionary containing all the variables
 function load(f::File{format"JLD2"}; kwargs...)
     jldopen(FileIO.filename(f), "r"; kwargs...) do file
-        loadtodict!(Dict{String,Any}(), file)
+        loadtodict!(Dict{Union{String,Symbol},Any}(), file)
     end
 end
 
 # When called with explicitly requested variable names, return each one
-function load(f::File{format"JLD2"}, varname::AbstractString; kwargs...)
+function load(f::File{format"JLD2"}, varname::StringOrSymbol; kwargs...)
     jldopen(FileIO.filename(f), "r"; kwargs...) do file
         read(file, varname)
     end
 end
 
-load(f::File{format"JLD2"}, varnames::AbstractString...; kwargs...) =
+load(f::File{format"JLD2"}, varnames::StringOrSymbol...; kwargs...) =
     load(f, varnames; kwargs...)
 
-function load(f::File{format"JLD2"}, varnames::Tuple{Vararg{AbstractString}}; kwargs...)
+function load(f::File{format"JLD2"}, varnames::Tuple{Vararg{StringOrSymbol}}; kwargs...)
     jldopen(FileIO.filename(f), "r"; kwargs...) do file
         map((var)->jlread(file, var), varnames)
     end

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -154,7 +154,11 @@ function loadtodict!(d::Dict, g::Union{JLDFile,Group}, prefix::String="")
         if v isa Group
             loadtodict!(d, v, prefix*k*"/")
         else
-            d[prefix*k] = v
+            if !isempty(prefix)
+                d[prefix*string(k)] = v
+            else
+                d[k] = v
+            end
         end
     end
     return d

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -272,3 +272,25 @@ end
 
     @test tup == (; ptr = Ptr{Float64}(0))
 end
+
+
+# Test for symbol identifiers
+@testset "Symbol Identifiers" begin
+    fn = joinpath(mktempdir(), "test.jld2")
+    data = Dict(:a => 1, :b => 2)
+    FileIO.save(fn, data)
+    @test isempty(setdiff(keys(FileIO.load(fn)), keys(data)))
+
+    data = Dict(:a => 1, "b" => 2)
+    FileIO.save(fn, data)
+    @test isempty(setdiff(keys(FileIO.load(fn)), keys(data)))
+
+    jldopen(fn, "w") do f
+        f[:a] = 1
+        write(f, :b, 2)
+    end
+    jldopen(fn, "r") do f
+        @test read(f, :a) == 1
+        @test f[:b] == 2
+    end
+end


### PR DESCRIPTION
Implement a symbol-identifier compatible API.

Internally all `Symbol` identifiers will be converted to `String` by prepending a double underscore `__`.