### PR TITLE
More printing

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -447,17 +447,25 @@ function Base.show(io::IO, f::JLDFile)
 end
 
 # fancy multi-line display (unless an IOContext requests compactness)
-function Base.show(io::IO, ::MIME"text/plain", f::JLDFile; numlines = get(io, :jld2_numlines, 10))
+function Base.show(io::IO, ::MIME"text/plain", f::JLDFile)
     show(io, f)
     if !get(io, :compact, false)
         print(io, "\n")
-        show_group(io, f.root_group, numlines, " ", true)
+        printtoc(io, f; numlines = get(io, :jld2_numlines, 10))
     end
 end
 
-# KLUDGE
-printtoc(io::IO, f::JLDFile) = show(io, MIME"text/plain"(), f, numlines = typemax(Int64))
-printtoc(f::JLDFile) = printtoc(Base.stdout, f)
+"""
+    printtoc([io::IO,] f::JLDFile [; numlines])
+Prints an overview of the contents of `f` to the `IO`.
+
+Use the optional `numlines` parameter to restrict the amount of items listed.
+"""
+printtoc(f::JLDFile; kwargs...) = printtoc(Base.stdout, f; kwargs...)
+printtoc(io::IO, f::JLDFile; numlines = typemax(Int64)) =
+    show_group(io, f.root_group, numlines, " ", true)
+
+
 
 include("superblock.jl")
 include("object_headers.jl")

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -500,5 +500,5 @@ end
 
 function Base.show(io::IO, g::Group)
     println(io, "JLD2.Group")
-    show_group(io, g, false, 10)
+    show_group(io, g, 10, " ", false)
 end


### PR DESCRIPTION
This PR changes the printing of `JLDFile`s in various ways

This is the normal case. The output is unchanged, but you can now optionally set the amount of lines displayed with an IOContext with the parameter `:jld2_numlines`. However, after implementing this feature, I already think that it shouldn't be added because it adds disproportionate amounts of weirdness. Also, the problem that I initially suggested this feature for is now solved more effectively (in my opinion) by the `printtoc` function (see below).
```
julia> f
JLDFile /home/lhupe/file.jld2 (read/write)
 ├─🔢 1
 ├─🔢 2
 ├─🔢 3
 ├─🔢 4
 ├─🔢 5
 ├─🔢 6
 ├─🔢 7
 ├─🔢 8
 ├─🔢 9
 └─ ⋯ (8 more entries)
```
Also, the two-argument and three-argument `show` functions now behave differently
```
julia> [f, f]
2-element Array{JLD2.JLDFile{JLD2.MmapIO},1}:
 JLDFile /home/lhupe/file.jld2 (read/write)
 JLDFile /home/lhupe/file.jld2 (read/write)
```
and observe `:compact` in `IOContexts`
```
julia> [f f]
1×2 Array{JLD2.JLDFile{JLD2.MmapIO},2}:
 JLDFile /home/lhupe/file.jld2  JLDFile /home/lhupe/file.jld2
```

The PR also introduces a new exported function, `printtoc`, which prints the table of contents. At the moment, the implementation is somewhat hacky…  
<details>

```
julia> printtoc(f)
 ├─🔢 1
 ├─🔢 2
 ├─🔢 3
 ├─🔢 4
 ├─🔢 5
 ├─🔢 6
 ├─🔢 7
 ├─🔢 8
 ├─🔢 9
 ├─🔢 10
 ├─🔢 11
 ├─🔢 12
 ├─🔢 13
 ├─🔢 14
 ├─🔢 15
 ├─📂 bar
 │  ├─🔢 1
 │  ├─🔢 2
 │  ├─🔢 3
 │  ├─🔢 4
 │  ├─🔢 5
 │  ├─🔢 6
 │  ├─🔢 7
 │  ├─🔢 8
 │  ├─🔢 9
 │  ├─🔢 10
 │  ├─🔢 11
 │  ├─🔢 12
 │  ├─🔢 13
 │  ├─🔢 14
 │  └─🔢 15
 └─🔢 reg9223372036854775775
```

</details>