### PR TITLE
Use precompile.jl only on most recent version

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -520,7 +520,7 @@ include("inlineunion.jl")
 include("fileio.jl")
 include("compression.jl")
 
-if Base.VERSION >= v"1.4.2"
+if Base.VERSION >= v"1.6.0"
     include("precompile.jl")
     _precompile_()
 end


### PR DESCRIPTION
On julia 1.5 this happens: #341 

Since `v1.5` is not officially supported, I will not spend the time to add optimization features to it.
referencing #340 