### PR TITLE
Auto conversion of convertible types 

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -521,9 +521,9 @@ include("inlineunion.jl")
 include("fileio.jl")
 include("compression.jl")
 
-if Base.VERSION >= v"1.6.0"
+#= if Base.VERSION >= v"1.6.0"
     include("precompile.jl")
     _precompile_()
-end
+end =#
 
 end # module

--- a/src/data/reconstructing_datatypes.jl
+++ b/src/data/reconstructing_datatypes.jl
@@ -180,7 +180,13 @@ function constructrr(f::JLDFile, T::DataType, dt::CompoundDatatype,
             # The on disk representation of T can only be the same as in memory
             # if the offsets are the same, field type on disk (readtype) and in memory (wstype)
             # are the same and if no CustomSerialization is involved
-            samelayout = samelayout && offsets[i] == fieldoffset(T, i) && types[i] === wstype && !(odrs[i] <: CustomSerialization)
+            samelayout = samelayout && 
+                offsets[i] == fieldoffset(T, i) && 
+                types[i] === wstype && 
+                # An OnDiskRepresentation as odr means that something "fixable" went wrong
+                # for this field
+                !(odrs[i] isa OnDiskRepresentation) && 
+                !(odrs[i] <: CustomSerialization)
 
             mapped[dtindex] = true
         end

--- a/test/modules-nested.jl
+++ b/test/modules-nested.jl
@@ -1,18 +1,3 @@
-function better_success(cmd)
-    fn1, _ = mktemp()
-    fn2, _ = mktemp()
-    try
-       run(pipeline(cmd, stdout=fn1, stderr=fn2))
-    catch
-        println(String(read(fn1)))
-        println(String(read(fn2)))
-        return false
-    end
-    return true
-end
-
-
-
 @testset "Nested modules" begin
     @testset "issue #112 - Random.DSFMT" begin
         tmpdir = mktempdir()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,19 @@
 using JLD2, FileIO
 using Test
 
+function better_success(cmd)
+    fn1, _ = mktemp()
+    fn2, _ = mktemp()
+    try
+       run(pipeline(cmd, stdout=fn1, stderr=fn2))
+    catch
+        println(String(read(fn1)))
+        println(String(read(fn2)))
+        return false
+    end
+    return true
+end
+
 include("bufferedreader.jl")
 include("lookup3.jl")
 include("internal.jl")


### PR DESCRIPTION
closes #354

This is a tricky thing but since it was already implemented, I'll just fix it for now.

Main idea: if the type of a struct field has changed, then JLD2 will check if there exists a `Base.convert(::Type{NewType}, oldtypeelement)` method. If there is, it will continue to reconstruct by calling `convert`.
This can however fail since e.g. `Base.convert(Float64, 3.14)` errors.

In that case, you end up with an annoying error that JLD2 cannot recover from. Only way out is to follow steps outlined in #242