### PR TITLE
Automatically transform symbol keys in strings with a warning

### DIFF
--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -6,7 +6,9 @@ function fileio_save(f::File{format"JLD2"}, dict::AbstractDict; kwargs...)
     jldopen(FileIO.filename(f), "w"; kwargs...) do file
         wsession = JLDWriteSession()
         for (k,v) in dict
-            if !isa(k, AbstractString)
+            if isa(k, Symbol)
+                @warn "you passed a key as a symbol instead of a string, it has been automatically converted"
+            elseif !isa(k, AbstractString)
                 throw(ArgumentError("keys must be strings (the names of variables), got $k"))
             end
             write(file, String(k), v, wsession)

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -95,6 +95,10 @@ end
 save(format"JLD2", fn, Dict("the"=>"quick", "brown"=>"fox", "stuff"=>reshape(1:4, (2, 2))))
 @test load(fn) == Dict("the"=>"quick", "brown"=>"fox", "stuff"=>reshape(1:4, (2, 2)))
 
+# Test Dict/save load with symbol keys
+save(format"JLD2", fn, Dict(:the=>"quick", :brown=>"fox", :stuff=>reshape(1:4, (2, 2))))
+@test load(fn) == Dict("the"=>"quick", "brown"=>"fox", "stuff"=>reshape(1:4, (2, 2)))
+
 # Test load/save with pairs
 save(format"JLD2", fn, "jumps", "over", "the", "lazy", "dog", reshape(1:4, (2, 2)))
 @test load(fn, "jumps", "the", "dog") == ("over", "lazy", reshape(1:4, (2, 2)))


### PR DESCRIPTION
This PR attempts to solve #358.
Since `String(k)` already works on symbols, I just added a warning when a key is a symbol.