### PR TITLE
Add a comment on `jldsave`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jldsave("example.jld2"; x, a=y, z)
 jldsave("example.jld2"; z=x, x=y, y=z)
 ```
 
-Compression and non-default IO types may be set via positional arguments.
+In the above examples, `;` after the filename is important.Compression and non-default IO types may be set via positional arguments.
 
 ### File interface
 


### PR DESCRIPTION
Emphasize the importance of `;` in the description of `jldsave` function in README.md.
If one simply uses `,` instead of `;` at the start of the list of the variables to be saved, one gets errors.