### PR TITLE
switch to OrderedCollections.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,10 +3,10 @@ uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 version = "0.4.20"
 
 [deps]
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -14,9 +14,9 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-DataStructures = "0.17, 0.18"
 FileIO = "1"
 MacroTools = "0.5"
 Reexport = "1"
 TranscodingStreams = "0.9"
 julia = "1.6"
+OrderedCollections = "1"

--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -1,5 +1,6 @@
 module JLD2
-using DataStructures, Reexport
+using OrderedCollections: OrderedDict
+using Reexport
 import Base.sizeof
 using MacroTools
 using Printf


### PR DESCRIPTION
Just noticed that the definition of `OrderedDict` has been moved to `OrderedCollections.jl`. Switching out the dependency (away from `DataStructures.jl`)
improves load time `using JLD2` from ~0.5s to ~0.35s.
