### PR TITLE
DRAFT: env + binary blobs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 

--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -7,6 +7,7 @@ using FileIO: load, save
 export load, save
 using Requires: @require
 using PrecompileTools: @setup_workload, @compile_workload
+using Serialization: Serialization
 
 export jldopen, @load, @save, save_object, load_object, printtoc
 export jldsave
@@ -506,6 +507,8 @@ include("fileio.jl")
 include("compression.jl")
 include("explicit_datasets.jl")
 include("committed_datatype_introspection.jl")
+include("metadata.jl")
+include("write_blob.jl")
 
 
 if ccall(:jl_generating_output, Cint, ()) == 1   # if we're precompiling the package

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -1,0 +1,30 @@
+
+function write_env(f::JLDFile)
+    project = read(Base.active_project(), String)
+    manifest = read(
+        joinpath(dirname(Base.active_project()), "Manifest.toml"),
+            String)
+
+    f["_metadata/project"] = project
+    f["_metadata/manifest"] = manifest
+    return nothing
+end
+
+function has_env(f::JLDFile)
+    haskey(f, "_metadata/project")
+end
+
+function read_env(f::JLDFile)
+    project = f["_metadata/project"]
+    manifest = f["_metadata/manifest"]
+    return (Pkg.TOML.parse(project), Pkg.TOML.parse(manifest))
+end
+
+function Pkg.activate(f::JLDFile, path=mktempdir(); kwargs...)
+    mkpath(path)
+    write(joinpath(path, "Project.toml"), f["_metadata/project"])
+    write(joinpath(path, "Manifest.toml"), f["_metadata/manifest"])
+    Pkg.activate(path; kwargs...)
+end
+
+

--- a/src/write_blob.jl
+++ b/src/write_blob.jl
@@ -1,0 +1,43 @@
+struct SerializedBlob
+    blob::Vector{UInt8}
+end
+
+struct Blob
+    obj::Any
+end
+
+Blob(blob::Blob) = blob
+
+function wconvert(::Type{SerializedBlob}, obj::Blob)
+    buffer = IOBuffer()
+    Serialization.serialize(buffer, obj)
+    result = take!(buffer)
+    return SerializedBlob(result)
+end
+
+function rconvert(::Type{Blob}, blob::SerializedBlob)
+   obj = Serialization.deserialize(IOBuffer(blob.blob))
+   return Blob(obj) 
+end
+
+writeas(::Type{Blob}) = SerializedBlob
+
+write_blob(f::JLDFile, name, obj; compress=nothing) = 
+    write_blob(f.root_group, name, obj; compress)
+
+
+function write_blob(g::Group, name::AbstractString, obj; compress=nothing)
+    f = g.f
+    prewrite(f)
+    (g, name) = pathize(g, name, true)
+    if !isnothing(compress)
+        cur_compress = f.compress
+        f.compress = compress
+        g[name] = write_dataset(f, Blob(obj), JLDWriteSession())
+        f.compress = cur_compress
+    else
+        g[name] = write_dataset(f, Blob(obj), JLDWriteSession())
+    end
+    return nothing
+end
+


### PR DESCRIPTION
This is a demonstration implementation of two things inspired by `JLSO.jl`

It adds definition `write_env(f)`, `has_env(f)`, `read_env(f)` and `Pkg.activate(f::JLDFile)` to write, check, read, and activate an environment stored in a file.

It also adds a proof of concept custom serialization `Blob`. `Blob` has a single field of type `Any` that gets serialized using `Serialization.serialize`. 

```
julia> f = jldopen("test2.jld2", "w")
JLDFile /home/jonas/.julia/dev/JLD2/test2.jld2 (read/write)
  (no datasets)

julia> JLD2.write_blob(f, "h", ()->rand(2,2))

julia> close(f)

## new session

julia> d = load("test2.jld2")
Dict{String, Any} with 1 entry:
  "h" => Blob(#7)

julia> d["h"].obj()
2×2 Matrix{Float64}:
 0.983637  0.0874438
 0.641339  0.81356
```

alternatively write `jldsave("test.jld2"; a=JLD2.Blob(()->rand(3,3)))`

a proper API for wrapping and unwrapping in `Blob`s could of course be built.



EDIT: it might be better to store the enviroment metadata as attributes.
