### PR TITLE
Don't access `.size` directly

### DIFF
--- a/src/data/type_defs.jl
+++ b/src/data/type_defs.jl
@@ -4,7 +4,7 @@ const Pointers = Union{Ptr{Cvoid}, IndirectPointer}
 
 struct OnDiskRepresentation{Offsets,JLTypes,H5Types, Size} end
 odr_sizeof(::Nothing) = 0
-@Base.pure odr_sizeof(x::DataType) = Int(x.size)
+@Base.pure odr_sizeof(x::DataType) = Int(sizeof(x))
 
 struct UnknownType{T}
     name::T


### PR DESCRIPTION
This broke on Julia nightly

https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/f1ae425_vs_317211a/Bio3DView.against.log

x-ref: https://github.com/JuliaLang/julia/pull/47170