### PR TITLE
struct upgrade pathway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.29
+ - added `Upgrade` feature
+ 
 ## 0.4.28
  - compatibility to julia v1.9-dev (@eschnett)
  

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD2"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.28"
+version = "0.4.29"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/docs/src/customserialization.md
+++ b/docs/src/customserialization.md
@@ -1,8 +1,4 @@
-# Custom Serialization (Experimental)
-
-Version `v0.3.0` of introduces support for custom serialization.
-For now this feature is considered experimental as it passes tests but 
-has little testing in the wild. → Please test and report if you encounter problems.
+# Custom Serialization
 
 The API is simple enough, to enable custom serialization for your type `A` you define
 a new type e.g. `ASerialization` that contains the fields you want to store and define

--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -145,6 +145,15 @@ read as type `S`.
 """
 struct CustomSerialization{T,S} end
 
+"""
+    Upgrade(T)
+
+Specify an upgrade path for serialized structs using the `typemap`` keyword argument
+and `rconvert`.
+"""
+struct Upgrade
+    target
+end
 
 struct Filter
     id::UInt16

--- a/src/data/reconstructing_datatypes.jl
+++ b/src/data/reconstructing_datatypes.jl
@@ -342,7 +342,15 @@ function jlconvert(rr::ReadRepresentation{T,DataTypeODR()},
 
     params, unknown_params = types_from_refs(f, ptr+odr_sizeof(Vlen{UInt8}))
     # For cross-platform compatibility convert integer type parameters to system precision
-    params = [p isa Union{Int64,Int32} ? Int(p) : p for p in params]
+    params = map(params) do p
+        if p isa Union{Int64,Int32}
+            Int(p)
+        elseif p isa Upgrade
+            p.target
+        else
+            p
+        end
+    end
     hasparams = !isempty(params)
     mypath = String(jlconvert(ReadRepresentation{UInt8,Vlen{UInt8}}(), f, ptr, NULL_REFERENCE))
 

--- a/src/data/reconstructing_datatypes.jl
+++ b/src/data/reconstructing_datatypes.jl
@@ -243,6 +243,20 @@ function constructrr(f::JLDFile, T::DataType, dt::CompoundDatatype,
     end
 end
 
+function constructrr(f::JLDFile, u::Upgrade, dt::CompoundDatatype,
+                     attrs::Vector{ReadAttribute},
+                     hard_failure::Bool=false)
+    field_datatypes = read_field_datatypes(f, attrs)
+
+
+    rodr = reconstruct_odr(f, dt, field_datatypes)
+    types = typeof(rodr).parameters[2].parameters
+
+    T2 = NamedTuple{tuple(dt.names...), typeof(rodr).parameters[2]}
+
+    return (ReadRepresentation{u.target, CustomSerialization{T2, rodr}}(), false)    
+end
+
 function constructrr(f::JLDFile, T::UnionAll, dt::CompoundDatatype,
                      attrs::Vector{ReadAttribute},
                      hard_failure::Bool=false)

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -266,10 +266,14 @@ function read_data(f::JLDFile,
                 if isa(T, UnknownType)
                     str = typestring(T)
                     @warn("type $(str) does not exist in workspace; interpreting Array{$str} as Array{Any}")
-                    T = Any
+                    rr = ReadRepresentation{Any,RelOffset}()
+                elseif T isa Upgrade
+                    rr = ReadRepresentation{T.target, CustomSerialization{Any, RelOffset}}()
+                else
+                    rr = ReadRepresentation{T, RelOffset}()
                 end
                 seek(io, startpos)
-                return read_array(f, dataspace, ReadRepresentation{T,RelOffset}(),
+                return read_array(f, dataspace, rr,
                                   layout, FilterPipeline(), header_offset, attributes)
             end
         end

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -268,7 +268,7 @@ function read_data(f::JLDFile,
                     @warn("type $(str) does not exist in workspace; interpreting Array{$str} as Array{Any}")
                     rr = ReadRepresentation{Any,RelOffset}()
                 elseif T isa Upgrade
-                    rr = ReadRepresentation{T.target, CustomSerialization{Any, RelOffset}}()
+                    rr = ReadRepresentation{T.target, RelOffset}()
                 else
                     rr = ReadRepresentation{T, RelOffset}()
                 end


### PR DESCRIPTION
This PR implements an experimental way of upgrading stored structs to an updated version. Example:

```julia
julia> struct A
       x::Int
       y::Float64
       end

julia> save_object("test.jld2", A(1,2.0))

julia> load_object("test.jld2")
A(1, 2.0)

julia> struct A2
           x::Float64
           y::Float64
           z::Float64 # x*y
       end

julia> JLD2.rconvert(::Type{A2}, nt::NamedTuple) = A2(Float64(nt.x), nt.y, nt.x*nt.y)

julia> JLD2.load("test.jld2", "single_stored_object"; typemap=Dict("Main.A" => JLD2.Upgrade(A2)))
A2(1.0, 2.0, 2.0)
```

API is clumsy but it was rather easy to implement and could potentially be powerful for some applications.

Please test and give feedback if you're interested.