### PR TITLE
allow loading compressed files during precompilation

### DIFF
--- a/src/compression.jl
+++ b/src/compression.jl
@@ -160,7 +160,7 @@ end
 function get_decompressor(filter_id::UInt16)
     modname, compressorname, decompressorname, = ID_TO_DECOMPRESSOR[filter_id]
     invoke_again, m = checked_import(modname)
-    return invoke_again, @eval $m.$decompressorname()
+    return invoke_again, getproperty(m,decompressorname)()
 end
 function get_decompressor(filters::FilterPipeline)
     decompressors = Any[]
@@ -168,7 +168,7 @@ function get_decompressor(filters::FilterPipeline)
     for filter in filters.filters
         modname, compressorname, decompressorname, = ID_TO_DECOMPRESSOR[filter.id]
         invoke_again, m = checked_import(modname)
-        push!(decompressors, @eval $m.$decompressorname())
+        push!(decompressors, getproperty(m,decompressorname)())
     end
     return invoke_again, decompressors
 end


### PR DESCRIPTION
If you try to load a compressed file during precompilation (like top-level of your module, or in a `SnoopPrecompile.@precompile_all_calls`), the `@eval` s were causing an error since you're evaling into another module which is not allowed. You can just `getproperty` directly I think, works for my case, will wait for full suite of tests below to see if there's not some edge case. 