### PR TITLE
Can't upgrade parametric types

### DIFF
--- a/src/data/reconstructing_datatypes.jl
+++ b/src/data/reconstructing_datatypes.jl
@@ -399,6 +399,7 @@ function jlconvert(rr::ReadRepresentation{T,DataTypeODR()},
 
     if mypath in keys(f.typemap)
         m = f.typemap[mypath]
+        m isa Upgrade && return m
     else
         m = _resolve_type(rr, f, ptr, header_offset, mypath, hasparams, hasparams ? params : nothing)
         m isa UnknownType && return m


### PR DESCRIPTION
previously it tried to to do

`Upgrade(NewStruct){OldStructparams....}`