### PR TITLE
Don't keep file in open files cache if it fails to read metadata

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -377,7 +377,12 @@ function jldopen(fname::AbstractString, wr::Bool, create::Bool, truncate::Bool, 
             f.types_group = Group{JLDFile{IOStream}}(f)
         end
     else
-        load_file_metadata!(f)
+        try
+            load_file_metadata!(f)
+        catch e
+            close(f)
+            rethrow(e)
+        end
     end
     merge!(f.typemap, typemap)
     return f

--- a/test/test_files.jl
+++ b/test/test_files.jl
@@ -124,7 +124,7 @@ testfiles = artifact"testfiles/JLD2TestFiles-0.1.0/artifacts"
 end
 
 @testset "Opening corrupted files" begin
-    mktemp() do (path, io)
+    mktemp() do path, io
         close(io)
         @test_throws EOFError jldopen(path)
         # We want to make sure that this didn't accidentally add itself to the open

--- a/test/test_files.jl
+++ b/test/test_files.jl
@@ -122,3 +122,15 @@ testfiles = artifact"testfiles/JLD2TestFiles-0.1.0/artifacts"
 
     end
 end
+
+@testset "Opening corrupted files" begin
+    mktemp() do (path, io)
+        close(io)
+        @test_throws EOFError jldopen(path)
+        # We want to make sure that this didn't accidentally add itself to the open
+        # files cache
+        @test_throws EOFError jldopen(path)
+        # Opening for overwriting should succeed
+        close(jldopen(path, "w+"))
+    end
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/1292