### PR TITLE
Align writeas for Dict with wconvert

### DIFF
--- a/src/data/specialcased_types.jl
+++ b/src/data/specialcased_types.jl
@@ -246,9 +246,7 @@ rconvert(::Type{Core.SimpleVector}, x::Vector{Any}) = Core.svec(x...)
 
 ## Dicts
 
-writeas(::Type{Dict{K,V}}) where {K,V} = Vector{Pair{K,V}}
-writeas(::Type{IdDict{Any,Any}}) = Vector{Pair{Any,Any}}
-writeas(::Type{Base.ImmutableDict{K,V}}) where {K,V} = Vector{Pair{K,V}}
+writeas(::Type{<:AbstractDict{K,V}}) where {K,V} = Vector{Pair{K,V}}
 wconvert(::Type{Vector{Pair{K,V}}}, x::AbstractDict{K,V}) where {K,V} = collect(x)
 function rconvert(::Type{T}, x::Vector{Pair{K,V}}) where {T<:AbstractDict,K,V}
     d = T()


### PR DESCRIPTION
Handles all cases, such as IdDict{K,V}. Seems to be likely the cause of the failure in https://github.com/JuliaLang/julia/pull/51319 / https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/abeb0f4_vs_3250804/JLD2.primary.log since it is trying to serialize the structure of the IdDict instead of the contents.