### PR TITLE
compat: no MmapIO for windows 7

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -61,7 +61,7 @@ is_win7() = Sys.iswindows() && Sys.windows_version().major <= 6 && Sys.windows_v
 const DEFAULT_IOTYPE = if is_win7()
     IOStream
 else
-    JLD2.MmapIO
+    MmapIO
 end
 
 """

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -237,7 +237,7 @@ is equivalent to
 To choose the io type `IOStream` instead of the default `MmapIO` use 
 `jldsave(fn, IOStream; kwargs...)`.
 """
-function jldsave(filename::AbstractString, compress=false, iotype::T=MmapIO; 
+function jldsave(filename::AbstractString, compress=false, iotype::T=DEFAULT_IOTYPE; 
                     kwargs...
                     ) where T<:Union{Type{IOStream},Type{MmapIO}}
     jldopen(filename, "w"; compress=compress, iotype=iotype) do f

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -23,10 +23,10 @@
         else
             jldsave(path; a, b, c, d, e, f, g, h)
             jldopen(path) do f
-            for k in keys(f)
-                f[k]
+                for k in keys(f)
+                    f[k]
+                end
             end
         end
-
     end
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -11,22 +11,25 @@
     h=rand(2000)
 
     @compile_workload begin
-
-        # Win7 and below systems use IOStream method to ensure pre-compilation correct
-        if Sys.iswindows() && Sys.windows_version().major <= 6 && Sys.windows_version().minor <= 1
-            jldsave(path, IOStream; a, b, c, d, e, f, g, h)
-            jldopen(path; iotype = IOStream) do f
-                for k in keys(f)
-                    f[k]
+        mktemp() do path, _
+            
+            # Win7 and below systems use IOStream method to ensure pre-compilation correct
+            if Sys.iswindows() && Sys.windows_version().major <= 6 && Sys.windows_version().minor <= 1
+                jldsave(path, IOStream; a, b, c, d, e, f, g, h)
+                jldopen(path; iotype = IOStream) do f
+                    for k in keys(f)
+                        f[k]
+                    end
+                end
+            else
+                jldsave(path; a, b, c, d, e, f, g, h)
+                jldopen(path) do f
+                    for k in keys(f)
+                        f[k]
+                    end
                 end
             end
-        else
-            jldsave(path; a, b, c, d, e, f, g, h)
-            jldopen(path) do f
-                for k in keys(f)
-                    f[k]
-                end
-            end
+            nothing
         end
     end
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -11,18 +11,22 @@
     h=rand(2000)
 
     @compile_workload begin
-        mktemp() do path, _
 
-            # jldsave
-            jldsave(path; a, b, c, d, e, f, g, h)
-
-            jldopen(path) do f
+        # Win7 and below systems use IOStream method to ensure pre-compilation correct
+        if Sys.iswindows() && Sys.windows_version().major <= 6 && Sys.windows_version().minor <= 1
+            jldsave(path, IOStream; a, b, c, d, e, f, g, h)
+            jldopen(path; iotype = IOStream) do f
                 for k in keys(f)
                     f[k]
                 end
             end
-
-            nothing
+        else
+            jldsave(path; a, b, c, d, e, f, g, h)
+            jldopen(path) do f
+            for k in keys(f)
+                f[k]
+            end
         end
+
     end
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -12,23 +12,16 @@
 
     @compile_workload begin
         mktemp() do path, _
-            
-            # Win7 and below systems use IOStream method to ensure pre-compilation correct
-            if Sys.iswindows() && Sys.windows_version().major <= 6 && Sys.windows_version().minor <= 1
-                jldsave(path, IOStream; a, b, c, d, e, f, g, h)
-                jldopen(path; iotype = IOStream) do f
-                    for k in keys(f)
-                        f[k]
-                    end
-                end
-            else
-                jldsave(path; a, b, c, d, e, f, g, h)
-                jldopen(path) do f
-                    for k in keys(f)
-                        f[k]
-                    end
+
+            # jldsave
+            jldsave(path; a, b, c, d, e, f, g, h)
+
+            jldopen(path) do f
+                for k in keys(f)
+                    f[k]
                 end
             end
+
             nothing
         end
     end


### PR DESCRIPTION
Ensure win7 can be precompiled
Win7 and below systems use IOStream method to ensure pre-compilation correct. 