### PR TITLE
Draft: experimental plain reconstruction

### DIFF
--- a/src/data/reconstructing_datatypes.jl
+++ b/src/data/reconstructing_datatypes.jl
@@ -98,6 +98,11 @@ function jltype(f::JLDFile, cdt::CommittedDatatype)
     end
 
     datatype = read_attr_data(f, julia_type_attr)
+    if !(datatype <: Tuple) && f.plain
+        rr = jltype(f, dt)
+        return f.h5jltype[cdt] = rr
+    end
+
     if written_type_attr !== nothing
         # Custom serialization
         custom_datatype = read_attr_data(f, written_type_attr)
@@ -415,6 +420,9 @@ function jlconvert(rr::ReadRepresentation{T,DataTypeODR()},
     isunknowntype(m) && return m
     unknown_params && return UnknownType{m, Tuple{params...}}
     if hasparams
+        if f.plain && !(m === Tuple)
+            return Any
+        end
         try
             m = m{params...}
         catch e

--- a/src/data/reconstructing_datatypes.jl
+++ b/src/data/reconstructing_datatypes.jl
@@ -98,7 +98,7 @@ function jltype(f::JLDFile, cdt::CommittedDatatype)
     end
 
     datatype = read_attr_data(f, julia_type_attr)
-    if !(datatype <: Tuple) && f.plain
+    if f.plain && !(datatype isa Upgrade) && !(datatype <: Tuple) 
         rr = jltype(f, dt)
         return f.h5jltype[cdt] = rr
     end

--- a/test/test_files.jl
+++ b/test/test_files.jl
@@ -258,3 +258,15 @@ end
     @test getfoo("readas_foo_a.jld2") isa Readas.Foo{Readas.UndefinedFunction}
     @test getfoo("readas_foo_n_a.jld2") isa Readas.FooNSerialization
 end
+
+
+@testset "plain reconstruction" begin
+    fn = joinpath(testfiles,"struct_reconstruction.jld2")
+    data = load(fn; plain=true)
+    # This is somewhat broken: Tuples are committed with field names "1", "2",...
+    # these are valid names but break most of the common API incl. the @NamedTuple macro
+    #@test data["tms"] == @NamedTuple{1::Int64, 2}((1, (a = 1,)))
+    @test getproperty(data["tms"], Symbol(1)) == 1
+    @test data["s"]   == (a = 1,)
+    @test data["ds"].kvvec[1]  == (; first = "a", second = (a = 1,))
+end


### PR DESCRIPTION
Tries to turn committed types into `NamedTuple` and (non-committed) parametric type signatures into `Any`. 

```
julia> load("struct_reconstruction.jld2"; plain=true)
Dict{String, Any} with 4 entries:
  "dms" => @NamedTuple{kvvec}((Any[@NamedTuple{first::String, second}(("a", (a = 1,)))],))
  "tms" => @NamedTuple{1::Int64, 2}((1, (a = 1,)))
  "s"   => (a = 1,)
  "ds"  => @NamedTuple{kvvec}((Any[(first = "a", second = (a = 1,))],))
```