### PR TITLE
Add @nospecializeinfer around worst offenders

### DIFF
--- a/src/compression.jl
+++ b/src/compression.jl
@@ -209,7 +209,7 @@ function deflate_data(f::JLDFile, data::Array{T}, odr::S, wsession::JLDWriteSess
 end
 
 
-@inline chunked_storage_message_size(ndims::Int) =
+chunked_storage_message_size(ndims::Int) =
     jlsizeof(HeaderMessage) + 5 + (ndims+1)*jlsizeof(Length) + 1 + jlsizeof(Length) + 4 + jlsizeof(RelOffset)
 
 

--- a/src/data/custom_serialization.jl
+++ b/src/data/custom_serialization.jl
@@ -18,20 +18,20 @@ CustomSerialization(::Type{WrittenAs}, ::Type{ReadAs}, odr) where {WrittenAs,Rea
 odr_sizeof(::Type{CustomSerialization{T,ODR}}) where {T,ODR} = odr_sizeof(ODR)
 
 # Usually we want to convert the object and then write it.
-@inline h5convert!(out::Pointers, ::Type{CustomSerialization{T,ODR}}, f::JLDFile,
+h5convert!(out::Pointers, ::Type{CustomSerialization{T,ODR}}, f::JLDFile,
                    x, wsession::JLDWriteSession) where {T,ODR} =
     h5convert!(out, ODR, f, wconvert(T, x)::T, wsession)
 
 # When writing as a reference, we don't want to convert the object first. That
 # should happen automatically after write_dataset is called so that the written
 # object gets the right written_type attribute.
-@inline h5convert!(out::Pointers, odr::Type{CustomSerialization{T,RelOffset}},
+h5convert!(out::Pointers, odr::Type{CustomSerialization{T,RelOffset}},
                    f::JLDFile, x, wsession::JLDWriteSession) where {T} =
     h5convert!(out, RelOffset, f, x, wsession)
 
 # When writing as a reference to something that's being custom-serialized as an
 # array, we have to convert the object first.
-@inline h5convert!(out::Pointers, odr::Type{CustomSerialization{T,RelOffset}},
+h5convert!(out::Pointers, odr::Type{CustomSerialization{T,RelOffset}},
             f::JLDFile, x, wsession::JLDWriteSession) where {T<:Array} =
     h5convert!(out, RelOffset, f, wconvert(T, x)::T, wsession)
 

--- a/src/data/specialcased_types.jl
+++ b/src/data/specialcased_types.jl
@@ -202,7 +202,8 @@ h5fieldtype(::JLDFile, ::Type{T}, ::Type{T}, ::Initialized) where {T<:Array} =
     ReferenceDatatype()
 fieldodr(::Type{T}, ::Bool) where {T<:Array} = RelOffset
 
-@inline function odr(::Type{Array{T,N}}) where {T,N}
+function odr(A::Type{<:Array})
+    T = eltype(A)
     writtenas = writeas(T)
     CustomSerialization(writtenas, T, fieldodr(writtenas, false))
 end

--- a/src/data/writing_datatypes.jl
+++ b/src/data/writing_datatypes.jl
@@ -141,7 +141,7 @@ check_writtenas_type(::Any) = throw(ArgumentError("writeas(leaftype) must return
 h5type(f::JLDFile, x) = h5type(f, writeas(typeof(x)), x)
 
 # Make a compound datatype from a set of names and types
-Base.@nospecializeinfer  function commit_compound(f::JLDFile, names::AbstractVector{Symbol},
+@nospecializeinfer  function commit_compound(f::JLDFile, names::AbstractVector{Symbol},
                          @nospecialize(writtenas::DataType), @nospecialize(readas::Type))
     types = writtenas.types
     offsets = Int[]
@@ -186,7 +186,7 @@ Base.@nospecializeinfer  function commit_compound(f::JLDFile, names::AbstractVec
 end
 
 # Write an HDF5 datatype to the file
-Base.@nospecializeinfer function commit(f::JLDFile,
+@nospecializeinfer function commit(f::JLDFile,
         @nospecialize(dtype),#::H5Datatype,
         @nospecialize(writeas::DataType),
         @nospecialize(readas::DataType),

--- a/src/data/writing_datatypes.jl
+++ b/src/data/writing_datatypes.jl
@@ -141,8 +141,8 @@ check_writtenas_type(::Any) = throw(ArgumentError("writeas(leaftype) must return
 h5type(f::JLDFile, x) = h5type(f, writeas(typeof(x)), x)
 
 # Make a compound datatype from a set of names and types
-function commit_compound(f::JLDFile, names::AbstractVector{Symbol},
-                         writtenas::DataType, readas::Type)
+Base.@nospecializeinfer  function commit_compound(f::JLDFile, names::AbstractVector{Symbol},
+                         @nospecialize(writtenas::DataType), @nospecialize(readas::Type))
     types = writtenas.types
     offsets = Int[]
     h5names = Symbol[]
@@ -186,7 +186,7 @@ function commit_compound(f::JLDFile, names::AbstractVector{Symbol},
 end
 
 # Write an HDF5 datatype to the file
-function commit(f::JLDFile,
+Base.@nospecializeinfer function commit(f::JLDFile,
         @nospecialize(dtype),#::H5Datatype,
         @nospecialize(writeas::DataType),
         @nospecialize(readas::DataType),

--- a/src/dataio.jl
+++ b/src/dataio.jl
@@ -31,15 +31,15 @@ function read_compressed_array! end
 # Cutoff for using ordinary IO instead of copying into mmapped region
 const MMAP_CUTOFF = 1048576
 
-@inline function read_scalar(f::JLDFile{MmapIO}, rr, header_offset::RelOffset)
+function read_scalar(f::JLDFile{MmapIO}, @nospecialize(rr), header_offset::RelOffset)
     io = f.io
     inptr = io.curptr
-    obj = jlconvert(rr, f, inptr, header_offset)
+    obj = jlconvert(rr, f, inptr, header_offset)::eltype(rr)
     io.curptr = inptr + odr_sizeof(rr)
     obj
 end
 
-@inline function read_array!(v::Array{T}, f::JLDFile{MmapIO},
+function read_array!(v::Array{T}, f::JLDFile{MmapIO},
                              rr::ReadRepresentation{T,T}) where T
     io = f.io
     inptr = io.curptr
@@ -60,7 +60,7 @@ end
     v
 end
 
-@inline function read_array!(v::Array{T}, f::JLDFile{MmapIO},
+function read_array!(v::Array{T}, f::JLDFile{MmapIO},
                              rr::ReadRepresentation{T,RR}) where {T,RR}
     io = f.io
     inptr = io.curptr
@@ -175,7 +175,7 @@ end
 # IOStream/BufferedWriter
 #
 
-@inline function read_scalar(f::JLDFile{IOStream}, rr, header_offset::RelOffset)
+function read_scalar(f::JLDFile{IOStream}, rr, header_offset::RelOffset)
     r = Vector{UInt8}(undef, odr_sizeof(rr))
     @GC.preserve r begin
         unsafe_read(f.io, pointer(r), odr_sizeof(rr))
@@ -184,13 +184,13 @@ end
 end
 
 
-@inline function read_array!(v::Array{T}, f::JLDFile{IOStream},
+function read_array!(v::Array{T}, f::JLDFile{IOStream},
                              rr::ReadRepresentation{T,T}) where T
     unsafe_read(f.io, pointer(v), odr_sizeof(T)*length(v))
     v
 end
 
-@inline function read_array!(v::Array{T}, f::JLDFile{IOStream},
+function read_array!(v::Array{T}, f::JLDFile{IOStream},
                              rr::ReadRepresentation{T,RR}) where {T,RR}
     n = length(v)
     nb = odr_sizeof(RR)*n

--- a/src/dataio.jl
+++ b/src/dataio.jl
@@ -31,10 +31,10 @@ function read_compressed_array! end
 # Cutoff for using ordinary IO instead of copying into mmapped region
 const MMAP_CUTOFF = 1048576
 
-function read_scalar(f::JLDFile{MmapIO}, @nospecialize(rr), header_offset::RelOffset)
+function read_scalar(f::JLDFile{MmapIO}, @nospecialize(rr), header_offset::RelOffset)::Any
     io = f.io
     inptr = io.curptr
-    obj = jlconvert(rr, f, inptr, header_offset)::eltype(rr)
+    obj = jlconvert(rr, f, inptr, header_offset)
     io.curptr = inptr + odr_sizeof(rr)
     obj
 end
@@ -175,7 +175,7 @@ end
 # IOStream/BufferedWriter
 #
 
-function read_scalar(f::JLDFile{IOStream}, rr, header_offset::RelOffset)
+function read_scalar(f::JLDFile{IOStream}, rr, header_offset::RelOffset)::Any
     r = Vector{UInt8}(undef, odr_sizeof(rr))
     @GC.preserve r begin
         unsafe_read(f.io, pointer(r), odr_sizeof(rr))

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -422,7 +422,7 @@ function read_array(f::JLDFile, dataspace::ReadDataspace,
             chunks = read_v1btree_dataset_chunks(f, h5offset(f, layout.data_offset), layout.dimensionality)                
             vchunk = Array{T, Int(ndims)}(undef, reverse(layout.chunk_dimensions)...)
             for chunk in chunks
-                cidx = chunk.idx::NTuple{ndims, Int}
+                cidx = chunk.idx::NTuple{Int(ndims), Int}
                 idx = reverse(cidx[1:end-1])
                 seek(io, fileoffset(f, chunk.offset))
                 indexview =  (:).(idx .+1, min.(idx .+ reverse(layout.chunk_dimensions), size(v)))

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -422,7 +422,7 @@ function read_array(f::JLDFile, dataspace::ReadDataspace,
             chunks = read_v1btree_dataset_chunks(f, h5offset(f, layout.data_offset), layout.dimensionality)                
             vchunk = Array{T, Int(ndims)}(undef, reverse(layout.chunk_dimensions)...)
             for chunk in chunks
-                cidx = chunkidx::NTuple{ndims, Int}
+                cidx = chunk.idx::NTuple{ndims, Int}
                 idx = reverse(cidx[1:end-1])
                 seek(io, fileoffset(f, chunk.offset))
                 indexview =  (:).(idx .+1, min.(idx .+ reverse(layout.chunk_dimensions), size(v)))

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -468,7 +468,7 @@ function payload_size_without_storage_message(dataspace::WriteDataspace, datatyp
 end
 
 
-Base.@nospecializeinfer function write_dataset(
+@nospecializeinfer function write_dataset(
         f::JLDFile,
         dataspace::WriteDataspace,
         datatype::H5Datatype,
@@ -541,7 +541,7 @@ Base.@nospecializeinfer function write_dataset(
     h5offset(f, header_offset)
 end
 
-@noinline Base.@nospecializeinfer function write_dataset(f::JLDFile, dataspace::WriteDataspace, datatype::H5Datatype, @nospecialize(odr), @nospecialize(data), wsession::JLDWriteSession)
+@nospecializeinfer function write_dataset(f::JLDFile, dataspace::WriteDataspace, datatype::H5Datatype, @nospecialize(odr), @nospecialize(data), wsession::JLDWriteSession)
     io = f.io
     datasz = (odr_sizeof(odr)::Int * numel(dataspace))
     psz = payload_size_without_storage_message(dataspace, datatype)
@@ -642,7 +642,7 @@ define_packed(ContiguousStorageMessage)
         4, LC_CONTIGUOUS_STORAGE, offset, datasz
     )
 
-@noinline Base.@nospecializeinfer function write_dataset(f::JLDFile, @nospecialize(x), wsession::JLDWriteSession)::RelOffset
+@nospecializeinfer function write_dataset(f::JLDFile, @nospecialize(x), wsession::JLDWriteSession)::RelOffset
     if ismutabletype(typeof(x)) && !isa(wsession, JLDWriteSession{Union{}})
         offset = get(wsession.h5offset, objectid(x), UNDEFINED_ADDRESS)
         offset != UNDEFINED_ADDRESS && return offset

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -468,15 +468,16 @@ function payload_size_without_storage_message(dataspace::WriteDataspace, datatyp
 end
 
 
-function write_dataset(
+Base.@nospecializeinfer function write_dataset(
         f::JLDFile,
         dataspace::WriteDataspace,
         datatype::H5Datatype,
-        odr::S,
-        data::Array{T},
+        @nospecialize(odr),
+        @nospecialize(data::Array),
         wsession::JLDWriteSession,
-        compress = f.compress,
-        ) where {T,S}
+        @nospecialize(compress = f.compress),
+        )
+    T = eltype(data)
     io = f.io
     datasz = odr_sizeof(odr)::Int * numel(dataspace)::Int
     #layout_class
@@ -540,7 +541,7 @@ function write_dataset(
     h5offset(f, header_offset)
 end
 
-function write_dataset(f::JLDFile, dataspace::WriteDataspace, datatype::H5Datatype, odr::S, data, wsession::JLDWriteSession) where S
+@noinline Base.@nospecializeinfer function write_dataset(f::JLDFile, dataspace::WriteDataspace, datatype::H5Datatype, @nospecialize(odr), @nospecialize(data), wsession::JLDWriteSession)
     io = f.io
     datasz = (odr_sizeof(odr)::Int * numel(dataspace))
     psz = payload_size_without_storage_message(dataspace, datatype)
@@ -641,7 +642,7 @@ define_packed(ContiguousStorageMessage)
         4, LC_CONTIGUOUS_STORAGE, offset, datasz
     )
 
-function write_dataset(f::JLDFile, x, wsession::JLDWriteSession)
+@noinline Base.@nospecializeinfer function write_dataset(f::JLDFile, @nospecialize(x), wsession::JLDWriteSession)::RelOffset
     if ismutabletype(typeof(x)) && !isa(wsession, JLDWriteSession{Union{}})
         offset = get(wsession.h5offset, objectid(x), UNDEFINED_ADDRESS)
         offset != UNDEFINED_ADDRESS && return offset
@@ -650,7 +651,7 @@ function write_dataset(f::JLDFile, x, wsession::JLDWriteSession)
     write_dataset(f, WriteDataspace(f, x, odr), h5type(f, x), odr, x, wsession)::RelOffset
 end
 
-write_ref(f::JLDFile, x, wsession::JLDWriteSession) = write_dataset(f, x, wsession)::RelOffset
+write_ref(f::JLDFile, @nospecialize(x), wsession::JLDWriteSession) = write_dataset(f, x, wsession)::RelOffset
 write_ref(f::JLDFile, x::RelOffset, wsession::JLDWriteSession) = x
 
 Base.delete!(f::JLDFile, x::AbstractString) = delete!(f.root_group, x)

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -422,7 +422,7 @@ function read_array(f::JLDFile, dataspace::ReadDataspace,
             chunks = read_v1btree_dataset_chunks(f, h5offset(f, layout.data_offset), layout.dimensionality)                
             vchunk = Array{T, Int(ndims)}(undef, reverse(layout.chunk_dimensions)...)
             for chunk in chunks
-                cidx = chunk.idx::NTuple{Int(ndims), Int}
+                cidx = chunk.idx::NTuple{Int(ndims+1), Int}
                 idx = reverse(cidx[1:end-1])
                 seek(io, fileoffset(f, chunk.offset))
                 indexview =  (:).(idx .+1, min.(idx .+ reverse(layout.chunk_dimensions), size(v)))

--- a/src/inlineunion.jl
+++ b/src/inlineunion.jl
@@ -32,7 +32,7 @@ function writeasbits(T::Union)
     length(types) == 2 && isbitstype(types[1]) && isbitstype(types[2])
 end
 
-Base.@nospecializeinfer function write_dataset(f::JLDFile, @nospecialize(x::Array), wsession::JLDWriteSession, @nospecialize(compress=f.compress))
+@nospecializeinfer function write_dataset(f::JLDFile, @nospecialize(x::Array), wsession::JLDWriteSession, @nospecialize(compress=f.compress))
     T = eltype(x)
     if !isa(wsession, JLDWriteSession{Union{}})
         offset = get(wsession.h5offset, objectid(x), UNDEFINED_ADDRESS)

--- a/src/inlineunion.jl
+++ b/src/inlineunion.jl
@@ -32,7 +32,8 @@ function writeasbits(T::Union)
     length(types) == 2 && isbitstype(types[1]) && isbitstype(types[2])
 end
 
-function write_dataset(f::JLDFile, x::Array{T}, wsession::JLDWriteSession, compress=f.compress) where {T}
+Base.@nospecializeinfer function write_dataset(f::JLDFile, @nospecialize(x::Array), wsession::JLDWriteSession, @nospecialize(compress=f.compress))
+    T = eltype(x)
     if !isa(wsession, JLDWriteSession{Union{}})
         offset = get(wsession.h5offset, objectid(x), UNDEFINED_ADDRESS)
         offset != UNDEFINED_ADDRESS && return offset

--- a/src/julia_compat.jl
+++ b/src/julia_compat.jl
@@ -21,3 +21,11 @@ else
         fieldcount(T) - T.name.n_uninitialized
     end
 end
+
+@static if VERSION < v"1.10.0"
+    macro nospecializeinfer(exp)
+        esc(exp)
+    end
+else
+    using Base: @nospecializeinfer
+end

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -149,13 +149,14 @@ macro load(filename, vars...)
     end
 end
 
-function loadtodict!(d::Dict, g::Union{JLDFile,Group}, prefix::String="")
+
+function loadtodict!(d::Dict, g::Union{JLDFile, Group}, prefix::String="")
     for k in keys(g)
         v = g[k]
         if v isa Group
-            loadtodict!(d, v, prefix*k*"/")
+            loadtodict!(d, g[k], prefix*k*"/")
         else
-            d[prefix*k] = v
+            d[prefix*k] = g[k]
         end
     end
     return d
@@ -243,7 +244,9 @@ end
 
 
 """
-    jldsave(filename, compress=false; kwargs...)
+    jldsave(filename; kwargs...)
+    jldsave(filename, compress; kwargs...)
+    jldsave(filename, compress, iotype; kwargs...)
 
 Creates a JLD2 file at `filename` and stores the variables given as keyword arguments.
 

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -263,14 +263,19 @@ is equivalent to
 To choose the io type `IOStream` instead of the default `MmapIO` use 
 `jldsave(fn, IOStream; kwargs...)`.
 """
-function jldsave(filename::AbstractString, compress=false, iotype::T=DEFAULT_IOTYPE; 
+function jldsave(filename::AbstractString, compress=false, iotype::Union{Type{IOStream},Type{MmapIO}}=DEFAULT_IOTYPE; 
                     kwargs...
-                    ) where T<:Union{Type{IOStream},Type{MmapIO}}
-    jldopen(filename, "w"; compress=compress, iotype=iotype) do f
+                    )
+    f = jldopen(filename, "w"; compress, iotype)
+    try
         wsession = JLDWriteSession()
         for (k,v) in pairs(kwargs)
             write(f, string(k), v, wsession)
         end
+    catch e 
+        throw(e)
+    finally
+        close(f)
     end
 end
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -9,18 +9,22 @@
     f="A String"
     g=ntuple(i->i^2, 5)
     h=rand(2000)
+    i=:asymbol
 
     @compile_workload begin
         mktemp() do path, _
 
             # jldsave
-            jldsave(path; a, b, c, d, e, f, g, h)
+            jldsave(path; a, b, c, d, e, f, g, h, i)
 
             jldopen(path) do f
                 for k in keys(f)
                     f[k]
                 end
             end
+
+            load(path)
+            load(path; nested=true)
 
             nothing
         end

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -708,11 +708,7 @@ end
         s_type = Tuple{Int, Tuple{Vararg{Int, T}} where T}
         a = Dict{s_type, Int}()
         a[(0, (1, 2, 3))] = 4
-        if VERSION < v"1.7.0-A"
-            @test_broken a == (save_object("test.jld2", a); load_object("test.jld2"))
-        else
-            @test a == (save_object("test.jld2", a); load_object("test.jld2"))
-        end
+        @test a == (save_object("test.jld2", a); load_object("test.jld2"))
     end
 end 
 


### PR DESCRIPTION
This improves time to first execution in particular when handling many types.
Resolves the ancient issue #2 (this is where the test code below is from)

JLD2 v0.4.41
```
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.10.0 (2023-12-25)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> include("jldtest.jl")
Precompiling JLD2
  1 dependency successfully precompiled in 18 seconds. 10 already precompiled.
  1.474348 seconds (2.41 M allocations: 157.608 MiB, 13.24% gc time, 99.76% compilation time)
  0.213206 seconds (358.63 k allocations: 23.462 MiB, 3.82% gc time, 99.71% compilation time)
 43.048239 seconds (100.61 M allocations: 6.450 GiB, 3.16% gc time, 99.84% compilation time)

julia> include("jldtest.jl")
  0.000466 seconds (1.35 k allocations: 54.711 KiB)
  0.000492 seconds (1.26 k allocations: 51.461 KiB)
  0.006597 seconds (27.15 k allocations: 1.185 MiB)
```


This PR
```            _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.10.0 (2023-12-25)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> include("tupletest.jl")
  0.223693 seconds (122.60 k allocations: 8.262 MiB, 34.51% gc time, 97.49% compilation time)
  0.178638 seconds (182.30 k allocations: 11.534 MiB, 94.68% compilation time)
  0.543427 seconds (692.44 k allocations: 46.006 MiB, 2.65% gc time, 88.67% compilation time)

julia> include("tupletest.jl")
  0.000982 seconds (2.88 k allocations: 127.492 KiB)
  0.007700 seconds (21.34 k allocations: 930.008 KiB)
  0.012911 seconds (47.05 k allocations: 2.141 MiB)
```

fixes #2


Loading has also been improved significantly. The file from above:
JLD2 v0.4.41:
```
julia> @time load("valtypes.jld2");
 17.044142 seconds (9.38 M allocations: 647.871 MiB, 1.51% gc time, 99.19% compilation time)

julia> @time load("valtypes.jld2");
  0.045572 seconds (84.62 k allocations: 10.131 MiB, 23.01% gc time)
```

this PR:
```
julia> @time load("valtypes.jld2");
  0.748558 seconds (690.43 k allocations: 51.296 MiB, 15.69% gc time, 94.32% compilation time)

julia> @time load("valtypes.jld2");
  0.036137 seconds (88.80 k allocations: 10.255 MiB)
```