### PR TITLE
experimental disable commit

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -50,6 +50,10 @@ is_win7() = Sys.iswindows() && Sys.windows_version().major <= 6 && Sys.windows_v
 # Windows 7 doesn't support mmap, falls back to IOStream
 const DEFAULT_IOTYPE = is_win7() ? IOStream : MmapIO
 
+# Experimental feature:
+# Set this variable to true to disallow committing any structs and instead error.
+const DISABLE_COMMIT = Ref(false)
+
 """
     Group{T}
     Group(file::T)

--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -50,10 +50,6 @@ is_win7() = Sys.iswindows() && Sys.windows_version().major <= 6 && Sys.windows_v
 # Windows 7 doesn't support mmap, falls back to IOStream
 const DEFAULT_IOTYPE = is_win7() ? IOStream : MmapIO
 
-# Experimental feature:
-# Set this variable to true to disallow committing any structs and instead error.
-const DISABLE_COMMIT = Ref(false)
-
 """
     Group{T}
     Group(file::T)
@@ -112,6 +108,8 @@ mutable struct JLDFile{T<:IO}
     compress#::Union{Bool,Symbol}
     mmaparrays::Bool
     n_times_opened::Int
+    # Experimental feature: disable committing structs
+    disable_commit::Bool
     datatype_locations::OrderedDict{RelOffset,CommittedDatatype}
     datatypes::Vector{H5Datatype}
     datatype_wsession::JLDWriteSession{Dict{UInt,RelOffset}}
@@ -131,7 +129,7 @@ mutable struct JLDFile{T<:IO}
     function JLDFile{T}(io::IO, path::AbstractString, writable::Bool, written::Bool,
                         compress,#::Union{Bool,Symbol},
                         mmaparrays::Bool) where T
-        f = new(io, path, writable, written, compress, mmaparrays, 1,
+        f = new(io, path, writable, written, compress, mmaparrays, 1, false,
             OrderedDict{RelOffset,CommittedDatatype}(), H5Datatype[],
             JLDWriteSession(), Dict{String,Any}(), IdDict(), IdDict(), Dict{RelOffset,WeakRef}(),
             DATA_START, Dict{RelOffset,GlobalHeap}(),

--- a/src/data/writing_datatypes.jl
+++ b/src/data/writing_datatypes.jl
@@ -144,6 +144,9 @@ h5type(f::JLDFile, @nospecialize(x)) = h5type(f, writeas(typeof(x)), x)
 # Make a compound datatype from a set of names and types
 @nospecializeinfer  function commit_compound(f::JLDFile, names::AbstractVector{Symbol},
                          @nospecialize(writtenas::DataType), @nospecialize(readas::Type))
+    if DISABLE_COMMIT[]
+        error("Attempted to commit DataType $writtenas but committing is disabled. (`JLD2.DISABLE_COMMIT[]==true`)")
+    end
     types = writtenas.types
     offsets = Int[]
     h5names = Symbol[]
@@ -192,6 +195,9 @@ end
         @nospecialize(writeas::DataType),
         @nospecialize(readas::DataType),
         attributes::WrittenAttribute...)
+    if DISABLE_COMMIT[]
+        error("Attempted to commit DataType $readas but committing is disabled. (`JLD2.DISABLE_COMMIT[]==true`)")
+    end
     io = f.io
 
     # This needs to be written this way or type inference gets unhappy...
@@ -362,6 +368,9 @@ function h5fieldtype(f::JLDFile, ::Type{T}, readas::Type, ::Initialized) where T
     end
     
     @lookup_committed f DataType
+    if DISABLE_COMMIT[]
+        error("Attempted to commit DataType $readas but committing is disabled. (`JLD2.DISABLE_COMMIT[]==true`)")
+    end
     io = f.io
     offset = f.end_of_data
 

--- a/src/data/writing_datatypes.jl
+++ b/src/data/writing_datatypes.jl
@@ -144,8 +144,8 @@ h5type(f::JLDFile, @nospecialize(x)) = h5type(f, writeas(typeof(x)), x)
 # Make a compound datatype from a set of names and types
 @nospecializeinfer  function commit_compound(f::JLDFile, names::AbstractVector{Symbol},
                          @nospecialize(writtenas::DataType), @nospecialize(readas::Type))
-    if DISABLE_COMMIT[]
-        error("Attempted to commit DataType $writtenas but committing is disabled. (`JLD2.DISABLE_COMMIT[]==true`)")
+    if f.disable_commit
+        throw(ArgumentError("Attempted to commit DataType $writtenas but committing is disabled."))
     end
     types = writtenas.types
     offsets = Int[]
@@ -195,8 +195,8 @@ end
         @nospecialize(writeas::DataType),
         @nospecialize(readas::DataType),
         attributes::WrittenAttribute...)
-    if DISABLE_COMMIT[]
-        error("Attempted to commit DataType $readas but committing is disabled. (`JLD2.DISABLE_COMMIT[]==true`)")
+    if f.disable_commit
+        throw(ArgumentError("Attempted to commit DataType $readas but committing is disabled."))
     end
     io = f.io
 
@@ -368,8 +368,8 @@ function h5fieldtype(f::JLDFile, ::Type{T}, readas::Type, ::Initialized) where T
     end
     
     @lookup_committed f DataType
-    if DISABLE_COMMIT[]
-        error("Attempted to commit DataType $readas but committing is disabled. (`JLD2.DISABLE_COMMIT[]==true`)")
+    if f.disable_commit
+        throw(ArgumentError("Attempted to commit DataType $readas but committing is disabled."))
     end
     io = f.io
     offset = f.end_of_data

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -744,3 +744,14 @@ end
     end
 end
 
+@testset "Disable committing datatypes" begin
+    cd(mktempdir()) do
+        JLD2.DISABLE_COMMIT[] = true
+        @test_throws "Attempted to commit DataType" JLD2.save_object("test.jld2", Dict(1=>2))
+        @test_throws "Attempted to commit DataType" JLD2.save_object("test.jld2", Vector{Float64})
+        @test_throws "Attempted to commit DataType" JLD2.save_object("test.jld2", (1,2,3))
+        # this could eventually be allowed
+        @test_throws "Attempted to commit DataType" JLD2.save_object("test.jld2", (; a=1, b=2))
+        JLD2.DISABLE_COMMIT[] = false
+    end
+end

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -746,12 +746,14 @@ end
 
 @testset "Disable committing datatypes" begin
     cd(mktempdir()) do
-        JLD2.DISABLE_COMMIT[] = true
-        @test_throws "Attempted to commit DataType" JLD2.save_object("test.jld2", Dict(1=>2))
-        @test_throws "Attempted to commit DataType" JLD2.save_object("test.jld2", Vector{Float64})
-        @test_throws "Attempted to commit DataType" JLD2.save_object("test.jld2", (1,2,3))
-        # this could eventually be allowed
-        @test_throws "Attempted to commit DataType" JLD2.save_object("test.jld2", (; a=1, b=2))
-        JLD2.DISABLE_COMMIT[] = false
+        jldopen("test.jld2", "w") do f
+            f.disable_commit = true
+
+            @test_throws ArgumentError f["1"] = Dict(1=>2)
+            @test_throws ArgumentError f["2"] = Vector{Float64}
+            @test_throws ArgumentError f["3"] = (1,2,3)
+            # this could eventually be allowed
+            @test_throws ArgumentError f["4"] = (; a=1, b=2)
+        end
     end
 end


### PR DESCRIPTION
Set `JLD2.DISABLE_COMMIT[] = true` to throw errors instead of committing types to files.
Can be used to guarantee *plain* files.