### PR TITLE
Don't hide exception data during loading and saving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /test/test_out.jld
 
 docs/build/
+
+Manifest.toml
+.vscode/

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD2"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.49"
+version = "0.4.50"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -42,8 +42,6 @@ function fileio_load(f::File{format"JLD2"}; nested::Bool=false, kwargs...)
         else
             return loadtodict!(Dict{String,Any}(), file)
         end
-    catch e
-        throw(e)
     finally
         close(file)
     end
@@ -54,8 +52,6 @@ function fileio_load(f::File{format"JLD2"}, varname::AbstractString; kwargs...)
     file = jldopen(FileIO.filename(f), "r"; kwargs...)
     try
         return load_data_or_dict(file, varname)
-    catch e
-        throw(e)
     finally
         close(file)
     end
@@ -68,8 +64,6 @@ function fileio_load(f::File{format"JLD2"}, varnames::Tuple{Vararg{AbstractStrin
     file = jldopen(FileIO.filename(f), "r"; kwargs...)
     try
         return map(var -> load_data_or_dict(file, var),  varnames)
-    catch e
-        throw(e)
     finally
         close(file)
     end

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -275,8 +275,6 @@ function jldsave(filename::AbstractString, compress=false, iotype::Union{Type{IO
         for (k,v) in pairs(kwargs)
             write(f, string(k), v, wsession)
         end
-    catch e 
-        throw(e)
     finally
         close(f)
     end


### PR DESCRIPTION
This PR removes some rethrows which cause the real exception to be hidden (which makes using JLD2 more difficult
because I don't know the real reason an exception happened).
