### PR TITLE
Draft: Slicing

### DIFF
--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -34,11 +34,11 @@ struct BasicDatatype <: H5Datatype
 end
 define_packed(BasicDatatype)
 StringDatatype(::Type{String}, size::Integer) =
-    BasicDatatype(DT_STRING, 0x11, 0x00, 0x00, size)
+    BasicDatatype(UInt8(DT_STRING) | 0x3<<4, 0x11, 0x00, 0x00, size)
 OpaqueDatatype(size::Integer) =
-    BasicDatatype(DT_OPAQUE, 0x00, 0x00, 0x00, size) # XXX make sure ignoring the tag is OK
+    BasicDatatype(UInt8(DT_OPAQUE) | 0x3<<4, 0x00, 0x00, 0x00, size) # XXX make sure ignoring the tag is OK
 ReferenceDatatype() =
-    BasicDatatype(DT_REFERENCE, 0x00, 0x00, 0x00, jlsizeof(RelOffset))
+    BasicDatatype(UInt8(DT_REFERENCE) | 0x3<<4, 0x00, 0x00, 0x00, jlsizeof(RelOffset))
 
 function Base.:(==)(dt1::BasicDatatype, dt2::BasicDatatype)
     ret = true
@@ -124,7 +124,7 @@ struct BitFieldDatatype <: H5Datatype
 end
 define_packed(BitFieldDatatype)
 BitFieldDatatype(size) =
-    BitFieldDatatype(DT_BITFIELD, 0x00, 0x00, 0x00, size, 0, 8*size)
+    BitFieldDatatype(UInt8(DT_BITFIELD) | 0x3<<4, 0x00, 0x00, 0x00, size, 0, 8*size)
 
 
 struct FloatingPointDatatype <: H5Datatype
@@ -198,7 +198,7 @@ end
 
 function jlwrite(io::IO, dt::CompoundDatatype)
     n = length(dt.names)
-    jlwrite(io, BasicDatatype(DT_COMPOUND, n % UInt8, (n >> 8) % UInt8, 0x00, dt.size))
+    jlwrite(io, BasicDatatype(UInt8(DT_COMPOUND) | 0x3<<4, n % UInt8, (n >> 8) % UInt8, 0x00, dt.size))
     for i = 1:length(dt.names)
         # Name
         name = dt.names[i]
@@ -273,7 +273,7 @@ struct VariableLengthDatatype{T<:H5Datatype} <: H5Datatype
     basetype::T
 end
 VariableLengthDatatype(basetype::H5Datatype) =
-    VariableLengthDatatype{typeof(basetype)}(DT_VARIABLE_LENGTH, 0x00, 0x00, 0x00, 8+jlsizeof(RelOffset), basetype)
+    VariableLengthDatatype{typeof(basetype)}(UInt8(DT_VARIABLE_LENGTH) | 0x3<<4, 0x00, 0x00, 0x00, 8+jlsizeof(RelOffset), basetype)
 VariableLengthDatatype(class, bitfield1, bitfield2, bitfield3, size, basetype::H5Datatype) =
     VariableLengthDatatype{typeof(basetype)}(class, bitfield1, bitfield2, bitfield3, size, basetype)
 
@@ -288,7 +288,7 @@ jlsizeof(dt::VariableLengthDatatype) =
     jlsizeof(BasicDatatype) + jlsizeof(dt.basetype)
 
 function jlwrite(io::IO, dt::VariableLengthDatatype)
-    jlwrite(io, BasicDatatype(DT_VARIABLE_LENGTH, dt.bitfield1, dt.bitfield2, dt.bitfield3, dt.size))
+    jlwrite(io, BasicDatatype(UInt8(DT_VARIABLE_LENGTH) | 0x3<<4, dt.bitfield1, dt.bitfield2, dt.bitfield3, dt.size))
     jlwrite(io, dt.basetype)
 end
 

--- a/src/explicit_datasets.jl
+++ b/src/explicit_datasets.jl
@@ -526,7 +526,7 @@ function ArrayDataset(dset::Dataset)
     dt = dset.datatype
     return ArrayDataset(
         f, dset, 
-        reverse(dset.dataspace.dimensions), 
+        Int.(reverse(dset.dataspace.dimensions)), 
         fileoffset(f, dset.layout.data_address), 
         jltype(f, !(f.plain) && dt isa SharedDatatype ? get(f.datatype_locations, dt.header_offset, dt) : dt)
         )

--- a/src/explicit_datasets.jl
+++ b/src/explicit_datasets.jl
@@ -547,13 +547,13 @@ Base.getindex(dset::Dataset, I...) = ArrayDataset(dset)[I...]
 Base.getindex(dset::Dataset) = read_dataset(dset)
 Base.setindex!(dset::Dataset, v, i, I...) = Base.setindex!(ArrayDataset(dset), v, i, I...)
 
-function Base.getindex(A::ArrayDataset, i::Int)
+function Base.getindex(A::ArrayDataset, i::Integer)
     @boundscheck checkbounds(A, i)
     seek(A.f.io, A.data_address + (i-1)*odr_sizeof(A.rr))
     return read_scalar(A.f, A.rr, UNDEFINED_ADDRESS)
 end
 
-function Base.setindex!(A::ArrayDataset{T,N,ODR}, v, i::Int) where {T,N,ODR}
+function Base.setindex!(A::ArrayDataset{T,N,ODR}, v, i::Integer) where {T,N,ODR}
     @boundscheck checkbounds(A, i)
     A.f.writable || throw(ArgumentError("Cannot edit in read-only mode"))
     seek(A.f.io, A.data_address + (i-1)*odr_sizeof(A.rr))

--- a/src/macros_utils.jl
+++ b/src/macros_utils.jl
@@ -114,7 +114,7 @@ function linefun(ex)
         increment = esc(n)
         off_inc = :($offset += $increment)
         write_inc = :(write_zerobytes(io, $increment))
-        return [write_inc, off_inc, off_inc]
+        return [write_inc, off_inc, :(skip($io, $increment))]
     elseif @capture(ex, s_Symbol::T_) || @capture(ex, s_Symbol::T_ = v_)
         getprop_ = :($(esc(s)) = $kw.$(s))
         default = Symbol(s,"_default")

--- a/test/dataset_api.jl
+++ b/test/dataset_api.jl
@@ -32,3 +32,35 @@ using JLD2, Test
         @test load(fn)["d"] == zeros(1000,1000)
     end
 end
+
+@testset "Slicing & Updating" begin
+    cd(mktempdir()) do 
+        fn = "test.jld2"
+        jldsave(fn; a=42, b = [42 43 44; 45 46 47], c = [(0x00, 1f0), (0x42, 2f0)])
+        jldopen(fn) do f
+            dset = JLD2.get_dataset(f, "a")
+            @test dset[] == 42
+            
+            dset = JLD2.get_dataset(f, "b")
+            @test dset[] == [42 43 44; 45 46 47]
+            @test dset[1] == 42
+            @test dset[1,1] == 42
+            @test dset[1:2, 1:2] == [42 43; 45 46]
+            @test dset[1,1:2:3] == [42, 44]
+            @test_throws BoundsError dset[7]
+            @test_throws BoundsError dset[2,4]
+            @test_throws ArgumentError dset[1] = 1
+        end
+        jldopen(fn, "a") do f
+            dset = JLD2.get_dataset(f, "b")
+            dset[2] = -1
+            @test dset[] == [42 43 44; -1 46 47]
+            dset[1,1:2:3] = [1,5]
+            @test dset[] == [1 43 5; -1 46 47]
+
+            dset = JLD2.get_dataset(f, "c")
+            dset[2] = (0xff, 0f0)
+            @test f["c"] == [(0x00, 1f0), (0xff, 0f0)]
+        end
+    end
+end


### PR DESCRIPTION
Implements a dataset wrapper `ArrayDataset` that allows typestable slicing and update of array datasets using the `getindex` and `setindex!` API.