### PR TITLE
Cleanup of Lookup3 hash

### DIFF
--- a/src/Lookup3.jl
+++ b/src/Lookup3.jl
@@ -3,8 +3,6 @@ import JLD2: jlunsafe_load, pconvert
 
 # Original source at http://www.burtleburtle.net/bob/c/lookup3.c
 
-rot(x::UInt32, k) = xor(((x)<<(k)), ((x)>>(32-(k))))
-
 # -------------------------------------------------------------------------------
 # mix -- mix 3 32-bit values reversibly.
 
@@ -48,13 +46,13 @@ rot(x::UInt32, k) = xor(((x)<<(k)), ((x)>>(32-(k))))
 # rotates.
 # -------------------------------------------------------------------------------
 @inline function mix(a, b, c)
-  a -= c;  a = xor(a, rot(c, 4));  c += b
-  b -= a;  b = xor(b, rot(a, 6));  a += c
-  c -= b;  c = xor(c, rot(b, 8));  b += a
-  a -= c;  a = xor(a, rot(c,16));  c += b
-  b -= a;  b = xor(b, rot(a,19));  a += c
-  c -= b;  c = xor(c, rot(b, 4));  b += a
-  (a, b, c)
+    a -= c;  a ⊻= bitrotate(c, 4);  c += b
+    b -= a;  b ⊻= bitrotate(a, 6);  a += c
+    c -= b;  c ⊻= bitrotate(b, 8);  b += a
+    a -= c;  a ⊻= bitrotate(c,16);  c += b
+    b -= a;  b ⊻= bitrotate(a,19);  a += c
+    c -= b;  c ⊻= bitrotate(b, 4);  b += a
+    (a, b, c)
 end
 
 # # -------------------------------------------------------------------------------
@@ -81,14 +79,14 @@ end
 #  11  8 15 26 3 22 24
 # -------------------------------------------------------------------------------
 @inline function final(a, b, c)
-  c = xor(c, b); c -= rot(b,14)
-  a = xor(a, c); a -= rot(c,11)
-  b = xor(b, a); b -= rot(a,25)
-  c = xor(c, b); c -= rot(b,16)
-  a = xor(a, c); a -= rot(c,4)
-  b = xor(b, a); b -= rot(a,14)
-  c = xor(c, b); c -= rot(b,24)
-  c
+    c ⊻= b; c -= bitrotate(b,14)
+    a ⊻= c; a -= bitrotate(c,11)
+    b ⊻= a; b -= bitrotate(a,25)
+    c ⊻= b; c -= bitrotate(b,16)
+    a ⊻= c; a -= bitrotate(c, 4)
+    b ⊻= a; b -= bitrotate(a,14)
+    c ⊻= b; c -= bitrotate(b,24)
+    c
 end
 
 # -------------------------------------------------------------------------------
@@ -117,12 +115,12 @@ end
 # -------------------------------------------------------------------------------
 function hash(k::AbstractVector{UInt8}, istart::Integer=1, n::Integer=length(k), initval::UInt32=UInt32(0))
     n <= length(k) || throw(BoundsError())
-    hash(pointer(k, istart), n, initval)
+    GC.@preserve k hash(pointer(k, istart), n, initval)
 end
 
 function hash(k::Ptr{UInt8}, n::Integer=length(k), initval::UInt32=UInt32(0))
     # Set up the internal state
-    a = b = c = 0xdeadbeef + convert(UInt32, n) + initval
+    a = b = c = 0xdeadbeef + n%UInt32 + initval
 
     # --------------- all but the last block: affect some 32 bits of (a,b,c)
     ptr = k

--- a/test/lookup3.jl
+++ b/test/lookup3.jl
@@ -15,3 +15,14 @@ for i = 1:length(large_buf)
 end
 @test JLD2.Lookup3.hash(large_buf) == 0x1bd2ee7b
 @test JLD2.Lookup3.hash(fill!(large_buf, 0)) == 0x930c7afc
+
+lookup3_test_hashes = [
+    0x276a0407, 0xc4f3b847, 0x3253e887, 0xf0dbeea6, 0xa496ca89, 0xa2773e81,
+    0xa88b6e6c, 0x2ca474f0, 0xe38ce8aa, 0xdb610bd1, 0x17f84daf, 0xccda323b,
+    0x114345a2, 0xc01e7c57, 0x636342ab, 0x17bd0180, 0xbed86ff9, 0xae721167,
+    0x9bc026d8, 0xaf53f65a, 0xbad83ad7, 0xcf6e279e, 0x8806c437, 0x4eaa9b13,
+    0x2b885021, 0x769e8a62, 0x7e5372be, 0xa70fa8be, 0x8b7a3c59, 0x17770551,
+]
+for (i, h) in enumerate(lookup3_test_hashes)
+    @test JLD2.Lookup3.hash(b"Four score and seven years ago"[begin:i]) == h
+end


### PR DESCRIPTION
This PR uses the `bitrotate` function added in Julia v1.5, it also changes a `convert(UInt32, n)` to `n%UInt32` when setting the initial state to match what happens in the C code. Lastly, it adds a missing `GC.@preserve` around where a pointer to an array is used.