### PR TITLE
Fix unions for upgrades on mutable structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.11
+ - Make `Upgrade` work for types that sit inside `Union{..}`
+
 ## 0.5.10
  - fix regression for `UInt32`
  - **Deprecation**: Do not rely on JLD2 to load a compression library. This feature will be removed in a future release. Instead explicitly add `using` statements into your scripts.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD2"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.5.10"
+version = "0.5.11"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/src/data/reconstructing_datatypes.jl
+++ b/src/data/reconstructing_datatypes.jl
@@ -333,6 +333,7 @@ function types_from_refs(f::JLDFile, ptr::Ptr)
             nulldt = CommittedDatatype(UNDEFINED_ADDRESS, 0)
             cdt = get(f.datatype_locations, ref, nulldt)
             res = cdt !== nulldt ? julia_repr(jltype(f, cdt)) : load_dataset(f, ref)
+            res isa Upgrade && (res = res.target)
             unknown_params |= isunknowntype(res) || isreconstructed(res)
             res
         end for ref in refs]

--- a/src/data/reconstructing_datatypes.jl
+++ b/src/data/reconstructing_datatypes.jl
@@ -354,8 +354,6 @@ function jlconvert(rr::MappedRepr{<:Type,DataTypeODR},
     params = map(params) do p
         if p isa Union{Int64,Int32}
             Int(p)
-        elseif p isa Upgrade
-            p.target
         else
             p
         end


### PR DESCRIPTION
Fixes https://github.com/JuliaIO/JLD2.jl/issues/628

It's a bit of a guess, but tests pass for me locally, including the test added here, which reproduces the issue on master for mutable structs.

On master
```
Error encountered while load File{DataFormat{:JLD2}, String}("a.jld2").

Fatal error:
mutable: Error During Test at /Users/ian/Documents/GitHub/JLD2.jl/test/loadsave.jl:750
  Got exception outside of a @test
  TypeError: in Union, expected Type, got a value of type JLD2.Upgrade
  Stacktrace:
    [1] jlconvert(::JLD2.MappedRepr{Union, JLD2.OnDiskRepresentation{(0, 16, 32), Tuple{String, Vector{Any}, Vector{Any}}, Tuple{JLD2.Vlen{String}, JLD2.Vlen{JLD2.RelOffset}, JLD2.Vlen{JLD2.RelOffset}}, 48}}, f::JLD2.JLDFile{JLD2.MmapIO}, ptr::Ptr{Nothing}, header_offset::JLD2.RelOffset)
      @ JLD2 ~/Documents/GitHub/JLD2.jl/src/data/writing_datatypes.jl:549
    [2] read_scalar(f::JLD2.JLDFile{JLD2.MmapIO}, rr::Any, header_offset::JLD2.RelOffset)
      @ JLD2 ~/Documents/GitHub/JLD2.jl/src/io/dataio.jl:107
...
Test Summary:                                     | Pass  Error  Total  Time
Issue #628 Upgrading structs that contains unions |    3      1      4  1.8s
  immutable                                       |    3             3  0.4s
  mutable                                         |           1      1  1.0s
ERROR: LoadError: Some tests did not pass: 3 passed, 0 failed, 1 errored, 0 broken.
in expression starting at /Users/ian/Documents/GitHub/JLD2.jl/test/loadsave.jl:740
in expression starting at /Users/ian/Documents/GitHub/JLD2.jl/test/runtests.jl:25
ERROR: Package JLD2 errored during testing
```

cc. @Octogonapus 