### PR TITLE
Dynamically determine the operating system on win7

### DIFF
--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -280,7 +280,7 @@ end
 To choose the io type `IOStream` instead of the default `MmapIO` use 
 `jldsave(fn, IOStream; kwargs...)`.
 """
-@nospecializeinfer function jldsave(filename::AbstractString, compress=false, iotype::Union{Type{IOStream},Type{MmapIO}}=DEFAULT_IOTYPE; 
+@nospecializeinfer function jldsave(filename::AbstractString, compress=false, iotype::Union{Type{IOStream},Type{MmapIO}}=DEFAULT_IOTYPE[]; 
                     @nospecialize(kwargs...)
                     )
     f = jldopen(filename, "w"; compress, iotype)


### PR DESCRIPTION
Although #509 has been resolved, there is still a problem.
For some reasons, We will build .julia in advance on win10 and then use it on win 7/win 10/win 11, which will cause the jldopen function of JLD2 on win 7 to be unavailable.Therefore, I need to dynamically determine the operating system to initialize DEFAULT_IOTYPE when JLD2 is initialized.