### PR TITLE
convert FileIO and UnPack to true extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,19 +3,26 @@ uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 version = "0.5.11"
 
 [deps]
-FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
+[weakdeps]
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+
+[extensions]
+FileIOExt = "FileIO"
+UnPackExt = "UnPack"
+
 [compat]
-FileIO = "1.5"
+FileIO = "1"
 MacroTools = "0.5.10"
+Mmap = "1"
 OrderedCollections = "1"
 PrecompileTools = "1"
-Requires = "1.3"
 TranscodingStreams = "0.9, 0.10, 0.11"
-julia = "1.6"
+UnPack = "1"
+julia = "1.9"

--- a/ext/FileIOExt.jl
+++ b/ext/FileIOExt.jl
@@ -1,0 +1,10 @@
+module FileIOExt
+
+import JLD2: fileio_load, fileio_save
+using JLD2: load, save
+using FileIO: FileIO, File, @format_str, filename
+
+fileio_save(f::File{format"JLD2"}, args...; kwargs...) = save(filename(f), args...; kwargs...)
+fileio_load(f::File{format"JLD2"}, args...; kwargs...) = load(filename(f), args...; kwargs...)
+
+end

--- a/ext/UnPackExt.jl
+++ b/ext/UnPackExt.jl
@@ -1,7 +1,11 @@
 # —————————————————————————————————————————————————————————————————————————————————————— #
 #             Extension of @unpack and @pack! function from UnPack.jl package            #
 # —————————————————————————————————————————————————————————————————————————————————————— #
-using .UnPack
+#
+module UnPackExt
+using JLD2
+using JLD2: JLDFile, MmapIO, Group
+using UnPack
 
 """
 Unpack fields from JLD2-structs created with e.g. `file = jldopen(path)`. Also works for JLD2-
@@ -31,4 +35,5 @@ close(file)
 """
 @inline function UnPack.pack!(file::Union{T, Group{T}}, ::Val{f}, val) where {f, T<:JLDFile{MmapIO}}
     file[string(f)] = val
+end
 end

--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -1,18 +1,15 @@
 module JLD2
+
 using OrderedCollections: OrderedDict
 using MacroTools: MacroTools, @capture
 using Mmap: Mmap
 using TranscodingStreams: TranscodingStreams
-using FileIO: load, save
-export load, save
-using Requires: @require
 using PrecompileTools: @setup_workload, @compile_workload
+
+VERSION >= v"1.11" && include_string(JLD2, "public load, save")
 export jldopen, @load, @save, save_object, load_object, jldsave
 
 include("types.jl")
-
-
-
 
 include("macros_utils.jl")
 include("io/mmapio.jl")
@@ -497,16 +494,12 @@ include("compression.jl")
 include("explicit_datasets.jl")
 include("committed_datatype_introspection.jl")
 
+# these will get defined when (and if) FileIO is used
+function fileio_load end
+function fileio_save end
 
 if ccall(:jl_generating_output, Cint, ()) == 1   # if we're precompiling the package
     include("precompile.jl")
-end
-
-function __init__()
-    # If UnPack.jl package is loaded, extend @unpack, @pack! for file-like interface
-    @require UnPack="3a884ed6-31ef-47d7-9d2a-63182c4928ed" begin
-        include("../ext/UnPackExt.jl")
-    end
 end
 
 end

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -1,9 +1,6 @@
-import FileIO
-using FileIO: File, @format_str
-
 # Save all the key-value pairs in the dict as top-level variables of the JLD
-function fileio_save(f::File{format"JLD2"}, dict::AbstractDict; kwargs...)
-    jldopen(FileIO.filename(f), "w"; kwargs...) do file
+function save(f, dict::AbstractDict; kwargs...)
+    jldopen(f, "w"; kwargs...) do file
         wsession = JLDWriteSession()
         for (k,v) in dict
             if isa(k, Symbol)
@@ -17,11 +14,11 @@ function fileio_save(f::File{format"JLD2"}, dict::AbstractDict; kwargs...)
 end
 
 # Or the names and values may be specified as alternating pairs
-function fileio_save(f::File{format"JLD2"}, name::AbstractString, value, pairs...; kwargs...)
+function save(f, name::AbstractString, value, pairs...; kwargs...)
     if isodd(length(pairs)) || !isa(pairs[1:2:end], Tuple{Vararg{AbstractString}})
         throw(ArgumentError("arguments must be in name-value pairs"))
     end
-    jldopen(FileIO.filename(f), "w"; kwargs...) do file
+    jldopen(f, "w"; kwargs...) do file
         wsession = JLDWriteSession()
         write(file, String(name), value, wsession)
         for i = 1:2:length(pairs)
@@ -30,12 +27,12 @@ function fileio_save(f::File{format"JLD2"}, name::AbstractString, value, pairs..
     end
 end
 
-fileio_save(f::File{format"JLD2"}, value...; kwargs...) = error("must supply a name for each variable")
+save(f, value...; kwargs...) = error("must supply a name for each variable")
 
 
 # load with just a filename returns a dictionary containing all the variables
-function fileio_load(f::File{format"JLD2"}; nested::Bool=false, kwargs...)
-    file = jldopen(FileIO.filename(f), "r"; kwargs...)
+function load(f; nested::Bool=false, kwargs...)
+    file = jldopen(f, "r"; kwargs...)
     try
         if nested
             return loadnesteddict(file)
@@ -48,8 +45,8 @@ function fileio_load(f::File{format"JLD2"}; nested::Bool=false, kwargs...)
 end
 
 # When called with explicitly requested variable names, return each one
-function fileio_load(f::File{format"JLD2"}, varname::AbstractString; kwargs...)
-    file = jldopen(FileIO.filename(f), "r"; kwargs...)
+function load(f, varname::AbstractString; kwargs...)
+    file = jldopen(f, "r"; kwargs...)
     try
         return load_data_or_dict(file, varname)
     finally
@@ -57,11 +54,11 @@ function fileio_load(f::File{format"JLD2"}, varname::AbstractString; kwargs...)
     end
 end
 
-fileio_load(f::File{format"JLD2"}, varnames::AbstractString...; kwargs...) =
-    fileio_load(f, varnames; kwargs...)
+load(f, varnames::AbstractString...; kwargs...) =
+    load(f, varnames; kwargs...)
 
-function fileio_load(f::File{format"JLD2"}, varnames::Tuple{Vararg{AbstractString}}; kwargs...)
-    file = jldopen(FileIO.filename(f), "r"; kwargs...)
+function load(f, varnames::Tuple{Vararg{AbstractString}}; kwargs...)
+    file = jldopen(f, "r"; kwargs...)
     try
         return map(var -> load_data_or_dict(file, var),  varnames)
     finally

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,5 +1,4 @@
 
-
 @setup_workload begin
     a=1
     b=2.0

--- a/test/compression.jl
+++ b/test/compression.jl
@@ -74,7 +74,7 @@ end
 
     N = 100
     a = (rand(N, N), rand(N, N))
-    save("test.jld2", "a", a; compress = true)
+    JLD2.save("test.jld2", "a", a; compress = true)
     """
 
     cd(mktempdir()) do

--- a/test/dataset_api.jl
+++ b/test/dataset_api.jl
@@ -1,4 +1,4 @@
-using JLD2, Test
+using JLD2, FileIO, Test
 
 @testset "Dataset API" begin
     cd(mktempdir()) do 

--- a/test/test_files.jl
+++ b/test/test_files.jl
@@ -1,4 +1,4 @@
-using Test, JLD2
+using Test, JLD2, FileIO
 using LazyArtifacts
 #=
 When adding test files to the JLD2Testfiles repo tag a new
@@ -176,7 +176,7 @@ end
 end
 
 module RecoverableChangesInStructs
-    using JLD2, Test
+    using JLD2, FileIO, Test
     fn = joinpath(Main.testfiles, "recoverable_changes_in structs.jld2")
     # for saving:
     # struct A; x::Int; end

--- a/test/wrapped_io.jl
+++ b/test/wrapped_io.jl
@@ -1,4 +1,4 @@
-using Test, JLD2
+using Test, JLD2, FileIO
 
 @testset "Write to IOBuffer" begin
     iobuf = IOBuffer()


### PR DESCRIPTION
Avoids the recursion of having FileIO expect to load JLD2 in the precompile script, triggering possible errors. The functions load and save were not previously documented as part of the API (although they still exist here as public functions when desired), and the tests even usually explicitly got them from FileIO when desired.

This is intended to fix CI for v1.12+ (dropping support for v1.8 and earlier which are EOL anyways since v1.9 add extensions)