### PR TITLE
support for Memory and MemoryRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.14
+ - Add support for `Memory` and `MemoryRef`
+
 ## 0.5.13
  - Make UnPack.jl compat into an extension
  - bumps lower compat for julia to v1.9

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD2"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.5.13"
+version = "0.5.14"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/src/data/specialcased_types.jl
+++ b/src/data/specialcased_types.jl
@@ -342,5 +342,5 @@ end
     wconvert(::Type{SerializedMemoryRef}, x::MemoryRef) =
         SerializedMemoryRef(1+(x.ptr_or_offset - x.mem.ptr)*x.mem.length÷sizeof(x.mem), x.mem)
 
-    rconvert(::Type{<:MemoryRef}, x::SerializedMemoryRef) = memoryref(x.ref, x.index)
+    rconvert(::Type{<:MemoryRef}, x::SerializedMemoryRef) = memoryref(x.ref, Int(x.index))
 end

--- a/src/data/specialcased_types.jl
+++ b/src/data/specialcased_types.jl
@@ -198,12 +198,18 @@ writeas(::Type{Ptr{T}}) where {T} = Nothing
 rconvert(::Type{Ptr{T}}, ::Nothing) where {T} = Ptr{T}(0)
 
 ## Arrays
+# In most cases, Memory must be treated in the exact same way as arrays.
+@static if VERSION >= v"1.11"
+    const ArrayMemory{T} = Union{Array{T}, Memory{T}}
+else
+    const ArrayMemory{T} = Array{T}
+end
 
-h5fieldtype(::JLDFile, ::Type{T}, ::Type{T}, ::Initialized) where {T<:Array} =
+h5fieldtype(::JLDFile, ::Type{T}, ::Type{T}, ::Initialized) where {T<:ArrayMemory} =
     ReferenceDatatype()
-fieldodr(::Type{T}, ::Bool) where {T<:Array} = RelOffset
+fieldodr(::Type{T}, ::Bool) where {T<:ArrayMemory} = RelOffset
 
-function odr(A::Type{<:Array})
+function odr(A::Type{<:ArrayMemory})
     T = eltype(A)
     writtenas = writeas(T)
     CustomSerialization(writtenas, T, fieldodr(writtenas, false))
@@ -213,18 +219,18 @@ end
 # array, it writes a reference to the actual array where the datatype is
 # committed and has a written_type attribute.
 function h5fieldtype(f::JLDFile, ::Type{T}, readas::DataType,
-                     ::Initialized) where T<:Array
+                     ::Initialized) where T<:ArrayMemory
     @lookup_committed f readas
     commit(f, ReferenceDatatype(), T, readas)
 end
-h5type(f::JLDFile, ::Type{T}, x) where {T<:Array} =
+h5type(f::JLDFile, ::Type{T}, x) where {T<:ArrayMemory} =
     h5fieldtype(f, T, typeof(x), Val{true})
 
-function h5type(f::JLDFile, ::Type{T}, ::T) where T<:Array
-    if T <: Array{Union{}}
+function h5type(f::JLDFile, ::Type{T}, ::T) where T<:ArrayMemory
+    if T <: ArrayMemory{Union{}}
         return ReferenceDatatype()
     end
-    ty = T.parameters[1]
+    ty = eltype(T)
     writtenas = writeas(ty)
     if !hasfielddata(writtenas)
         # This is a hacky way to generate an instance of ty
@@ -237,14 +243,14 @@ function h5type(f::JLDFile, ::Type{T}, ::T) where T<:Array
     end
 end
 
-_odr(writtenas::Type{T}, readas::Type{T}, odr) where {T<:Array} = odr
-_odr(writtenas::Type{T}, readas::DataType, odr) where {T<:Array} =
+_odr(writtenas::Type{T}, readas::Type{T}, odr) where {T<:ArrayMemory} = odr
+_odr(writtenas::Type{T}, readas::DataType, odr) where {T<:ArrayMemory} =
     CustomSerialization{writtenas,RelOffset}
 
 function constructrr(::JLDFile, ::Type{T}, dt::BasicDatatype,
-                     attrs::Vector{ReadAttribute}) where T<:Array
+                     attrs::Vector{ReadAttribute}) where T<:ArrayMemory
     dt.class == DT_REFERENCE || throw(UnsupportedFeatureException())
-    (MappedRepr{Array, RelOffset}(), true)
+    (MappedRepr{T, RelOffset}(), true)
 end
 
 ## SimpleVectors
@@ -322,4 +328,19 @@ end
 function jlconvert(::MappedRepr{Module,CustomSerialization{String,Vlen{String}}},
     f::JLDFile, ptr::Ptr, header_offset::RelOffset)
 rconvert(Module, jlconvert(MappedRepr{String, Vlen{String}}(), f, ptr, header_offset))
+end
+
+
+## MemoryRef
+@static if VERSION >= v"1.11"
+    struct SerializedMemoryRef
+        index::Int64
+        ref::Memory
+    end
+
+    writeas(::Type{<:MemoryRef}) = SerializedMemoryRef
+    wconvert(::Type{SerializedMemoryRef}, x::MemoryRef) =
+        SerializedMemoryRef(1+(x.ptr_or_offset - x.mem.ptr)*x.mem.length÷sizeof(x.mem), x.mem)
+
+    rconvert(::Type{<:MemoryRef}, x::SerializedMemoryRef) = memoryref(x.ref, x.index)
 end

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -231,7 +231,7 @@ end
     ismem = !isnothing(attributes) && any(attr->attr.name==:Memory, attributes)
     v = @static if VERSION >= v"1.11"
         if ismem
-            Memory{T}(undef, jlread(io, Int64))
+            Memory{T}(undef, Int(jlread(io, Int64)))
         else
             construct_array(io, T, Int(ndims))
         end

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -225,14 +225,23 @@ end
                     attributes::Union{Vector{ReadAttribute},Nothing})
     T = julia_repr(rr)
     io = f.io
-    data_offset = layout.data_offset
-    if !ischunked(layout) || (layout.chunk_indexing_type == 1)
-        ndims, offset = get_ndims_offset(f, dataspace, attributes)
+    ndims, offset = get_ndims_offset(f, dataspace, attributes)
+    seek(io, offset)
+    # figure out whether to construct an Array or a Memory
+    ismem = !isnothing(attributes) && any(attr->attr.name==:Memory, attributes)
+    v = @static if VERSION >= v"1.11"
+        if ismem
+            Memory{T}(undef, jlread(io, Int64))
+        else
+            construct_array(io, T, Int(ndims))
+        end
+    else
+        construct_array(io, T, Int(ndims))
+    end
 
-        seek(io, offset)
-        v = construct_array(io, T, Int(ndims))
+    if !ischunked(layout) || (layout.chunk_indexing_type == 1)
         n = length(v)
-        seek(io, data_offset)
+        seek(io, layout.data_offset)
         if iscompressed(filters)
             read_compressed_array!(v, f, rr, layout.data_length, filters)
         else
@@ -241,10 +250,7 @@ end
         track_weakref!(f, header_offset, v)
         v
     else
-        ndims, offset = get_ndims_offset(f, dataspace, attributes)
-        seek(io, offset)
-        v = construct_array(io, T, Int(ndims))
-        if layout.version == 3 
+        if layout.version == 3
             # version 1 B-tree
             # This version appears to be padding incomplete chunks
             chunks = read_v1btree_dataset_chunks(f, h5offset(f, layout.data_offset), layout.dimensionality)                
@@ -309,11 +315,11 @@ end
     psz = payload_size_without_storage_message(dataspace, datatype)
     psz += CONTINUATION_MSG_SIZE
 
-    # Figure out the layout 
-    if datasz == 0 || (!(data isa Array) && datasz < 8192)
+    # Figure out the layout
+    if datasz == 0 || (!(data isa ArrayMemory) && datasz < 8192)
         layout_class = LcCompact
         psz += jlsizeof(Val(HmDataLayout); layout_class, data_size=datasz)
-    elseif data isa Array && compress != false && isconcretetype(eltype(data)) && isbitstype(eltype(data))
+    elseif data isa ArrayMemory && compress != false && isconcretetype(eltype(data)) && isbitstype(eltype(data))
         # Only now figure out if the compression argument is valid
         invoke_again, filter_id, compressor = get_compressor(compress)
         if invoke_again

--- a/src/dataspaces.jl
+++ b/src/dataspaces.jl
@@ -75,23 +75,25 @@ WriteDataspace(f::JLDFile, x::Array{T,0}, ::Any) where {T} =
     WriteDataspace(DS_SIMPLE, (Length(1),),
               (WrittenAttribute(f, :dimensions, EMPTY_DIMENSIONS),))
 
-# Memory is basically a vector but needs an additional attribute
-# Ghost type array
-WriteDataspace(f::JLDFile, x::Memory{T}, ::Nothing) where {T} =
-   WriteDataspace(DS_NULL, (),
-             (WrittenAttribute(f, :dimensions, collect(Int64, reverse(size(x)))),
-             WrittenAttribute(f, :Memory, true)))
+@static if VERSION >= v"1.11"
+    # Memory is basically a vector but needs an additional attribute
+    # Ghost type array
+    WriteDataspace(f::JLDFile, x::Memory{T}, ::Nothing) where {T} =
+    WriteDataspace(DS_NULL, (),
+                (WrittenAttribute(f, :dimensions, collect(Int64, reverse(size(x)))),
+                WrittenAttribute(f, :Memory, true)))
 
-# Reference array
-WriteDataspace(f::JLDFile, x::Memory{T}, ::Type{RelOffset}) where {T} =
-    WriteDataspace(DS_SIMPLE, convert(Tuple{Vararg{Length}}, reverse(size(x))),
-              (WrittenAttribute(f, :julia_type, write_ref(f, T, f.datatype_wsession)),
-              WrittenAttribute(f, :Memory, true)))
+    # Reference array
+    WriteDataspace(f::JLDFile, x::Memory{T}, ::Type{RelOffset}) where {T} =
+        WriteDataspace(DS_SIMPLE, convert(Tuple{Vararg{Length}}, reverse(size(x))),
+                (WrittenAttribute(f, :julia_type, write_ref(f, T, f.datatype_wsession)),
+                WrittenAttribute(f, :Memory, true)))
 
-# isbitstype array
-WriteDataspace(f::JLDFile, x::Memory, ::Any) =
-    WriteDataspace(DS_SIMPLE, convert(Tuple{Vararg{Length}}, reverse(size(x))),
-    (WrittenAttribute(f, :Memory, true),))
+    # isbitstype array
+    WriteDataspace(f::JLDFile, x::Memory, ::Any) =
+        WriteDataspace(DS_SIMPLE, convert(Tuple{Vararg{Length}}, reverse(size(x))),
+        (WrittenAttribute(f, :Memory, true),))
+end
 
 
 jlsizeof(::Union{WriteDataspace{N},Type{WriteDataspace{N}}}) where {N} = 4 + jlsizeof(Length)*N

--- a/src/dataspaces.jl
+++ b/src/dataspaces.jl
@@ -75,6 +75,25 @@ WriteDataspace(f::JLDFile, x::Array{T,0}, ::Any) where {T} =
     WriteDataspace(DS_SIMPLE, (Length(1),),
               (WrittenAttribute(f, :dimensions, EMPTY_DIMENSIONS),))
 
+# Memory is basically a vector but needs an additional attribute
+# Ghost type array
+WriteDataspace(f::JLDFile, x::Memory{T}, ::Nothing) where {T} =
+   WriteDataspace(DS_NULL, (),
+             (WrittenAttribute(f, :dimensions, collect(Int64, reverse(size(x)))),
+             WrittenAttribute(f, :Memory, true)))
+
+# Reference array
+WriteDataspace(f::JLDFile, x::Memory{T}, ::Type{RelOffset}) where {T} =
+    WriteDataspace(DS_SIMPLE, convert(Tuple{Vararg{Length}}, reverse(size(x))),
+              (WrittenAttribute(f, :julia_type, write_ref(f, T, f.datatype_wsession)),
+              WrittenAttribute(f, :Memory, true)))
+
+# isbitstype array
+WriteDataspace(f::JLDFile, x::Memory, ::Any) =
+    WriteDataspace(DS_SIMPLE, convert(Tuple{Vararg{Length}}, reverse(size(x))),
+    (WrittenAttribute(f, :Memory, true),))
+
+
 jlsizeof(::Union{WriteDataspace{N},Type{WriteDataspace{N}}}) where {N} = 4 + jlsizeof(Length)*N
 numel(x::WriteDataspace{0}) = x.dataspace_type == DS_SCALAR ? 1 : 0
 numel(x::WriteDataspace) = Int(prod(x.size))

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -888,3 +888,28 @@ end
         end
     end
 end
+
+@static if VERSION >= v"1.11"
+    @testset "Support for Memory" begin
+        fn = joinpath(mktempdir(), "memorytype.jld2")
+        m = Memory{Int}(undef, 10)
+        mr = memoryref(m, 5)
+        jldsave(fn; m, mr)
+        d = load(fn)
+        @test d["m"] isa Memory
+        @test d["m"] == m
+        @test d["mr"][] == mr[]
+        @test d["mr"].mem === d["m"]
+
+        m = Memory{String}(undef, 2)
+        m[1] = "1"
+        m[2] = "2"
+        mr = memoryref(m, 2)
+        jldsave(fn; m, mr)
+        d = load(fn)
+        @test d["m"] isa Memory
+        @test d["m"] == m
+        @test d["mr"][] == mr[]
+        @test d["mr"].mem === d["m"]
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,5 +46,9 @@ using TestItemRunner
         deps_compat = (;
             ignore = [:Mmap,],
         ),
+        ambiguities = (;
+            # There is are ambiguity that can never be hit
+            exclude = [JLD2.write_data, JLD2.WriteDataspace],
+        )
     )
 end


### PR DESCRIPTION
Implements the required special handling of `Memory` and `MemoryRef`.

Memory is treated as a regular mutable object and hence, object identity is preserved.
(e.g. when doing
```
m = Memory{Int}(undef, 10)
mr = memoryref(m, 1)
jldsave("test.jld2"; m, mr)
d = load("test.jld2")
d["m"] === d["mr"].mem
```

However potential aliasing between `Array` and `Memory` objects is ignored.