### PR TITLE
dynamic is_win7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.16
+ - Make default iotype selection dynamic. Makes precompile files relocatable to win7. (#632)
+
 ## 0.5.15
  - Add full control over type mapping by providing a typemap function
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD2"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.5.15"
+version = "0.5.16"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -24,9 +24,9 @@ include("superblock.jl")
 include("misc.jl")
 
 
-is_win7() = Sys.iswindows() && Sys.windows_version().major <= 6 && Sys.windows_version().minor <= 1
 # Windows 7 doesn't support mmap, falls back to IOStream
-const DEFAULT_IOTYPE = is_win7() ? IOStream : MmapIO
+is_win7() = Sys.iswindows() && Sys.windows_version().major <= 6 && Sys.windows_version().minor <= 1
+default_iotype() = is_win7() ? IOStream : MmapIO
 
 """
     Group{T}
@@ -104,7 +104,7 @@ mutable struct JLDFile{T<:IO}
     root_group::Group{JLDFile{T}}
     types_group::Group{JLDFile{T}}
     base_address::UInt64
-    
+
 
     function JLDFile{T}(io::IO, path::AbstractString, writable::Bool, written::Bool,
                         plain::Bool,
@@ -162,19 +162,20 @@ FallbackType(::Type{IOStream}) = nothing
 
 const OPEN_FILES = Dict{String,WeakRef}()
 const OPEN_FILES_LOCK = ReentrantLock()
-function jldopen(fname::AbstractString, wr::Bool, create::Bool, truncate::Bool, iotype::T=DEFAULT_IOTYPE;
-                 fallback::Union{Type, Nothing} = FallbackType(iotype),
-                 compress=false,
-                 mmaparrays::Bool=false,
-                 typemap=default_typemap,
-                 parallel_read::Bool=false,
-                 plain::Bool=false
-                 ) where T<:Union{Type{IOStream},Type{MmapIO}}
-    mmaparrays && @warn "mmaparrays keyword is currently ignored" maxlog=1
+function jldopen(fname::AbstractString, wr::Bool, create::Bool, truncate::Bool,
+    iotype::T=default_iotype();
+    fallback::Union{Type,Nothing}=FallbackType(iotype),
+    compress=false,
+    mmaparrays::Bool=false,
+    typemap=default_typemap,
+    parallel_read::Bool=false,
+    plain::Bool=false
+) where T<:Union{Type{IOStream},Type{MmapIO}}
+    mmaparrays && @warn "mmaparrays keyword is currently ignored" maxlog = 1
     verify_compressor(compress)
 
     # Can only open multiple in parallel if mode is "r"
-    if parallel_read && (wr, create, truncate)  != (false, false, false)
+    if parallel_read && (wr, create, truncate) != (false, false, false)
         throw(ArgumentError("Cannot open file in a parallel context unless mode is \"r\""))
     end
 
@@ -187,10 +188,10 @@ function jldopen(fname::AbstractString, wr::Bool, create::Bool, truncate::Bool, 
             # catch existing file system entities that are not regular files
             !isfile(rname) && throw(ArgumentError("not a regular file: $fname"))
 
-            f = get(OPEN_FILES, rname, (;value=nothing)).value
+            f = get(OPEN_FILES, rname, (; value=nothing)).value
             # If in serial, return existing handle. In parallel always generate a new handle
             if !isnothing(f)
-                if parallel_read 
+                if parallel_read
                     f.writable && throw(ArgumentError("Tried to open file in a parallel context but it is open in write-mode elsewhere in a serial context."))
                 else
                     if truncate
@@ -276,7 +277,7 @@ Options for `mode`:
 - `"a"`/`"a+"`: Open for reading and writing, creating a new file if none exists, but
                 preserving the existing file if one is present
 """
-function jldopen(fname::Union{AbstractString, IO}, mode::AbstractString="r"; iotype=DEFAULT_IOTYPE, kwargs...)
+function jldopen(fname::Union{AbstractString, IO}, mode::AbstractString="r"; iotype=default_iotype(), kwargs...)
     (wr, create, truncate) = mode == "r"  ? (false, false, false) :
                              mode == "r+" ? (true, false, false) :
                              mode == "a" || mode == "a+" ? (true, true, false) :


### PR DESCRIPTION
a small change that makes the `is_win7` happen dynamically rather than at precompile time. 
It's basically free and solves an issue reported in #632

(supersedes #632 ) 