### PR TITLE
improved readmmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.16
+ - Improve `readmmap` to work on more types and misaligned data
+
 ## 0.5.15
  - Add full control over type mapping by providing a typemap function
 

--- a/src/data/writing_datatypes.jl
+++ b/src/data/writing_datatypes.jl
@@ -9,7 +9,7 @@ function track_weakref!(f::JLDFile, header_offset::RelOffset, @nospecialize v)
 end
 
 function track_weakref_if_untracked!(f::JLDFile, header_offset::RelOffset, @nospecialize v)
-    if header_offset !== NULL_REFERENCE 
+    if header_offset !== NULL_REFERENCE
         if !haskey(f.jloffset, header_offset) || isnothing(f.jloffset[header_offset].value)
             f.jloffset[header_offset] = WeakRef(v)
         end
@@ -59,7 +59,7 @@ function samelayout(@nospecialize(T::DataType))::Bool
         !samelayout(ty) && return false
         offset += sizeof(ty)
     end
-    return offset == sizeof(T)
+    return offset == Base.aligned_sizeof(T)
 end
 samelayout(::Type) = false
 
@@ -175,7 +175,7 @@ check_writtenas_type(::Any) = throw(ArgumentError("writeas(leaftype) must return
             anynondefault = true
             continue
         end
-        
+
         if isa(dtype, CommittedDatatype)
             # HDF5 cannot store relationships among committed
             # datatypes. We store these separately in an attribute.
@@ -387,7 +387,7 @@ function h5fieldtype(f::JLDFile, ::Type{T}, readas::Type, ::Initialized) where T
         @lookup_committed f readas
         return commit(f, H5TYPE_DATATYPE, DataType, readas)
     end
-    
+
     @lookup_committed f DataType
     io = f.io
     offset = f.end_of_data
@@ -472,7 +472,7 @@ function h5convert!(out::Pointers, ::Type{DataTypeODR}, f::JLDFile, T::Type{<: N
             # this also catches NTuples with indeterminate length
             refs = refs_from_types(f, params, wsession)
             store_vlen!(out+odr_sizeof(Vlen{UInt8}), RelOffset, f, refs, f.datatype_wsession)
-        end     
+        end
     else # actual NTuple with more than one entry
         store_vlen!(out, UInt8, f, unsafe_wrap(Vector{UInt8}, "NTuple"), f.datatype_wsession)
         ET = params[1] # T === Tuple{ET,ET,ET,...}

--- a/src/explicit_datasets.jl
+++ b/src/explicit_datasets.jl
@@ -428,10 +428,11 @@ function readmmap(dset::Dataset)
     dims = reverse([jlread(io, Int64) for i in 1:ndims])
     iobackend = io isa IOStream ? io : io.f
     seek(iobackend, DataLayout(f, dset.layout).data_offset)
-
-    if (data_offset % 8 == 0) ||
-       (data_offset % 2 == 0 && sizeof(T) == 2) ||
-       (data_offset % 4 == 0 && sizeof(T) == 4) ||
+    # May be pos != data_offset for files with custom offset
+    pos = position(iobackend)
+    if (pos % 8 == 0) ||
+       (pos % 2 == 0 && sizeof(T) == 2) ||
+       (pos % 4 == 0 && sizeof(T) == 4) ||
        (sizeof(T) == 1)
         # These are cases where we can directly mmap the data.
         Mmap.mmap(iobackend, Array{T,Int(ndims)}, dims)

--- a/src/explicit_datasets.jl
+++ b/src/explicit_datasets.jl
@@ -35,7 +35,7 @@ function create_dataset(
     layout = nothing,
     chunk=nothing,
     filters=FilterPipeline(),
-)  
+)
     if !isnothing(path)
         (parent, name) = pathize(g, path, true)
     else
@@ -81,7 +81,7 @@ function Base.show(io::IO, ::MIME"text/plain", dset::Dataset)
             println(io, prefix*"dataspace:")
             spacetype = ("Scalar", "Simple", "Null", "V1")[Int(ds.dataspace_type)+1]
             println(io, prefix*"\ttype: $(spacetype)")
-            println(io, prefix*"\tdimensions: $(ds.dimensions)")            
+            println(io, prefix*"\tdimensions: $(ds.dimensions)")
         else
             println(io, prefix*"dataspace: $(dset.dataspace)")
         end
@@ -146,10 +146,10 @@ function write_dataset(dataset::Dataset, data, wsession::JLDWriteSession=JLDWrit
     !isempty(dataset.name) && (dataset.parent[dataset.name] = offset)
     # Attributes
     attrs = map(collect(keys(pairs(dataset.attributes)))) do name
-       WrittenAttribute(f, name, dataset.attributes[name]) 
+       WrittenAttribute(f, name, dataset.attributes[name])
     end
     dataset = get_dataset(f, offset, dataset.parent, dataset.name)
-    dataset.header_chunk_info = 
+    dataset.header_chunk_info =
         attach_message(f, dataset.offset, attrs, wsession;
             chunk_start=dataset.header_chunk_info[1],
             chunk_end=dataset.header_chunk_info[2],
@@ -167,11 +167,11 @@ Read the data referenced by a dataset.
 function read_dataset(dset::Dataset)
     f = dset.parent.f
     read_data(f,
-        ReadDataspace(f, dset.dataspace), 
+        ReadDataspace(f, dset.dataspace),
         dset.datatype,
         DataLayout(f, dset.layout),
-        isnothing(dset.filters) ? FilterPipeline() : dset.filters, 
-        dset.offset, 
+        isnothing(dset.filters) ? FilterPipeline() : dset.filters,
+        dset.offset,
         collect(ReadAttribute, values(dset.attributes)))
 end
 
@@ -181,7 +181,7 @@ end
 Get a stored dataset from a file by name or path as a `Dataset` object.
 This may be useful for inspecting the metadata incl. types of a dataset.
 """
-get_dataset(f::JLDFile, args...; kwargs...) = 
+get_dataset(f::JLDFile, args...; kwargs...) =
     get_dataset(f.root_group, args...; kwargs...)
 
 function get_dataset(g::Group, name::String)
@@ -202,7 +202,7 @@ end
 
 function get_dataset(f::JLDFile, offset::RelOffset, g=f.root_group, name="")
     dset = Dataset(g, name, offset, nothing, nothing, nothing, OrderedDict{String,Any}(), false, FilterPipeline(), nothing)
-    
+
     hmitr = HeaderMessageIterator(f, offset)
     for msg in hmitr
         if msg.type == HmDataspace
@@ -219,9 +219,9 @@ function get_dataset(f::JLDFile, offset::RelOffset, g=f.root_group, name="")
         end
     end
 
-    dset.header_chunk_info = (; 
+    dset.header_chunk_info = (;
                 hmitr.chunk.chunk_start,
-                hmitr.chunk.chunk_end, 
+                hmitr.chunk.chunk_end,
                 next_msg_offset = hmitr.chunk.chunk_end-CONTINUATION_MSG_SIZE)
     return dset
 end
@@ -236,7 +236,7 @@ end
 
 # Links
 message_size(msg::Pair{String, RelOffset}) = jlsizeof(Val(HmLinkMessage); link_name=msg.first)
-write_header_message(io, f, msg::Pair{String, RelOffset}, _=nothing) = 
+write_header_message(io, f, msg::Pair{String, RelOffset}, _=nothing) =
     write_header_message(io, Val(HmLinkMessage); link_name=msg.first, target=msg.second)
 
 function attach_message(f::JLDFile, offset, messages, wsession=JLDWriteSession();
@@ -258,7 +258,7 @@ function attach_message(f::JLDFile, offset, messages, wsession=JLDWriteSession()
 
         msg = first(messages)
         sz = message_size(msg)
-        if remaining_space ≥ sz + 4 || remaining_space == sz 
+        if remaining_space ≥ sz + 4 || remaining_space == sz
             pos = position(io)
             write_header_message(io, f, msg)
             rsz = position(io) - pos
@@ -302,7 +302,7 @@ function attach_message(f::JLDFile, offset, messages, wsession=JLDWriteSession()
     tmp = max(continuation_size, minimum_continuation_size)
     # only replace if the gap is larger than 4 bytes
     tmp - continuation_size > 4 && (continuation_size = tmp)
-    
+
     # Object continuation message
     write_header_message(io, Val(HmObjectHeaderContinuation);
         continuation_offset=h5offset(f, continuation_start),
@@ -337,8 +337,8 @@ function attach_message(f::JLDFile, offset, messages, wsession=JLDWriteSession()
     #g.last_chunk_checksum_offset = f.end_of_data - 4
     # TODO: last_chunk_checksum_offset is not updated
     return header_chunk_info = (
-        chunk_start, 
-        chunk_end, 
+        chunk_start,
+        chunk_end,
         position(io)-24)
 end
 
@@ -353,7 +353,7 @@ function add_attribute(dset::Dataset, name::String, data, wsession=JLDWriteSessi
     end
     dset.attributes[name] = data
     if iswritten(dset)
-        dset.header_chunk_info = 
+        dset.header_chunk_info =
         attach_message(f, dset.offset, [WrittenAttribute(f,name,data)], wsession;
             chunk_start=dset.header_chunk_info[1],
             chunk_end=dset.header_chunk_info[2],
@@ -367,7 +367,7 @@ end
     attributes(dset::Dataset; plain::Bool=false)
 
 Return the attributes of a dataset as an `OrderedDict`.
-If `plain` is set to `true` then the values are returned as stored in the dataset object.  
+If `plain` is set to `true` then the values are returned as stored in the dataset object.
 """
 function attributes(dset::Dataset; plain::Bool=false)
     plain && return dset.attributes
@@ -382,11 +382,10 @@ end
 Check if a dataset can be memory-mapped. This can be useful for large arrays and for editing written arrays.
 
 An Array dataset may be mmapped if:
-    - `JLD2.samelayout(T) == true`: The element type is `isbits` and has a size that is a multiple of 8 bytes.
+    - `JLD2.samelayout(T) == true`: The element type is `isbits` and has a size that either 1, 2, 4, or a multiple of 8 bytes.
     - Uncompressed: Compressed arrays cannot be memory-mapped
     - Uses a contiguous layout: This is true for all array datasets written by JLD2 with version ≥ v0.4.52
-    - Offset in file is a multiple of 8 bytes: This is a requirement for Mmap.
-    - Windows: The file must be opened in read-only mode. This is a limitation of Mmap on Windows. 
+    - Windows: The file must be opened in read-only mode. This is a limitation of Mmap on Windows.
 """
 function ismmappable(dset::Dataset)
     iswritten(dset) || return false
@@ -423,13 +422,25 @@ function readmmap(dset::Dataset)
     rr = jltype(f, dt)
     T = julia_repr(rr)
     ndims, offset = get_ndims_offset(f, ReadDataspace(f, dset.dataspace), collect(values(dset.attributes)))
-    
+
     io = f.io
     seek(io, offset)
-    dims = [jlread(io, Int64) for i in 1:ndims]
+    dims = reverse([jlread(io, Int64) for i in 1:ndims])
     iobackend = io isa IOStream ? io : io.f
     seek(iobackend, DataLayout(f, dset.layout).data_offset)
-    return Mmap.mmap(iobackend, Array{T, Int(ndims)}, (reverse(dims)..., ))
+
+    if (data_offset % 8 == 0) ||
+       (data_offset % 2 == 0 && sizeof(T) == 2) ||
+       (data_offset % 4 == 0 && sizeof(T) == 4) ||
+       (sizeof(T) == 1)
+        # These are cases where we can directly mmap the data.
+        Mmap.mmap(iobackend, Array{T,Int(ndims)}, dims)
+    else
+        # A fallback for all other cases is to mmap the data as UInt8 and reinterpret it.
+        reinterpret(reshape, T,
+            Mmap.mmap(iobackend, Array{UInt8,Int(ndims) + 1}, (sizeof(T), dims...);)
+        )
+    end
 end
 
 @static if !Sys.iswindows()
@@ -488,7 +499,7 @@ function allocate_early(dset::Dataset, T::DataType)
     # Align contiguous chunk to 8 bytes in the file
     address = f.end_of_data + 8 - mod1(f.end_of_data, 8)
     data_address = h5offset(f, address)
-    write_header_message(cio, Val(HmDataLayout); 
+    write_header_message(cio, Val(HmDataLayout);
         layout_class, data_address, data_size=datasz)
 
     dset.header_chunk_info = (header_offset, position(cio)+20, position(cio))
@@ -528,9 +539,9 @@ function ArrayDataset(dset::Dataset)
     writable = f.writable && (dset.layout.layout_class == LcContiguous)
     rr = jltype(f, !(f.plain) && dt isa SharedDatatype ? get(f.datatype_locations, dt.header_offset, dt) : dt)
     return ArrayDataset(
-        f, dset, 
-        Int.(reverse(dset.dataspace.dimensions)), 
-        fileoffset(f, dset.layout.data_address), 
+        f, dset,
+        Int.(reverse(dset.dataspace.dimensions)),
+        fileoffset(f, dset.layout.data_address),
         rr,
         writable
         )

--- a/src/explicit_datasets.jl
+++ b/src/explicit_datasets.jl
@@ -435,7 +435,7 @@ function readmmap(dset::Dataset)
        (pos % 4 == 0 && sizeof(T) == 4) ||
        (sizeof(T) == 1)
         # These are cases where we can directly mmap the data.
-        Mmap.mmap(iobackend, Array{T,Int(ndims)}, dims)
+        Mmap.mmap(iobackend, Array{T,Int(ndims)}, (dims...,))
     else
         # A fallback for all other cases is to mmap the data as UInt8 and reinterpret it.
         reinterpret(reshape, T,

--- a/test/Artifacts.toml
+++ b/test/Artifacts.toml
@@ -1,7 +1,7 @@
 [testfiles]
-git-tree-sha1 = "898220ce869d52019b7029899bda91f21e6d86b8"
+git-tree-sha1 = "a7ed11c46dd79d18f1a38d5f0ae62aca9141df78"
 lazy = true
 
     [[testfiles.download]]
-    sha256 = "69bd4577477b9cd18b888322495ddc1edae109f70be5d0b073e5af4d3bf4b867"
-    url = "https://github.com/JonasIsensee/JLD2TestFiles/archive/refs/tags/v0.1.6.tar.gz"
+    sha256 = "b20722c3297fdba34ac8079fec5ead6dfeb14936ae95c2b19d4a2bf0117ef271"
+    url = "https://github.com/JonasIsensee/JLD2TestFiles/archive/refs/tags/v0.1.7.tar.gz"

--- a/test/test_files.jl
+++ b/test/test_files.jl
@@ -6,10 +6,10 @@ release and adapt Artifacts.toml and the line below accordingly.
     git clone git@github.com:JonasIsensee/JLD2TestFiles.git
 add file & commit
     git tag v0.1.X
-    git push 
+    git push
     git push --tags
 go to github and create a new release with name "v0.1.x"
-update Artifacts.toml: 
+update Artifacts.toml:
 1) navigate to testdir
 2) launch repl and run
     using Pkg
@@ -24,13 +24,13 @@ update Artifacts.toml:
         lazy=true)
 update artifact string below to reflect new version number
 =#
-testfiles = artifact"testfiles/JLD2TestFiles-0.1.6/artifacts"
+testfiles = artifact"testfiles/JLD2TestFiles-0.1.7/artifacts"
 
 @testset "HDF5 compat test files" begin
     # These are test files copied from the HDF5.jl test suite
-    
+
     fn = joinpath(testfiles,"compound.h5")
-    jldopen(fn) do f 
+    jldopen(fn) do f
         data = f["data"]
         @test data[1] == data[2]
         nt = data[1]
@@ -44,7 +44,7 @@ testfiles = artifact"testfiles/JLD2TestFiles-0.1.6/artifacts"
     fn = joinpath(testfiles,"h5ex_t_enum.h5")
     jldopen(fn) do f
         @test size(f["DS1"]) == (7,4)
-    end 
+    end
 
     fn = joinpath(testfiles,"h5ex_t_array.h5")
     jldopen(fn) do f
@@ -142,7 +142,7 @@ testfiles = artifact"testfiles/JLD2TestFiles-0.1.6/artifacts"
         @test f["shuffle_compressed_chunks"] == reshape(1:1000, 25, 40)
         @test size(f["incomplete_allocation"]) == (50,50,10)
         @test f["incomplete_allocation"][1:50,1:50, 2] == reshape(1:2500, 50,50)
-        #f["incomplete_allocation"][1,1,1] == 0 
+        #f["incomplete_allocation"][1,1,1] == 0
     end
 end
 
@@ -172,7 +172,7 @@ end
     fn = joinpath(testfiles, "unionall_typeparam.jld2")
     data = load(fn, "test")
     @test propertynames(data) == (:val,)
-    @test data.val == 4 
+    @test data.val == 4
 end
 
 module RecoverableChangesInStructs
@@ -292,4 +292,13 @@ end
 
     ms = load(fn, "ms"; plain=true)
     @test ms == (; a=1, d=2.0)
+end
+
+@testset "Mmap with misaligned data" begin
+    fn = joinpath(testfiles, "mmapfile.h5")
+    f = jldopen(fn)
+    ds = JLD2.get_dataset(f, "arr")
+    arr = JLD2.readmmap(ds)
+    @test arr isa Base.ReinterpretArray
+    @test arr == 1:100
 end


### PR DESCRIPTION
This PR improves the `readmmap` function.
It will now figure out the byte alignment and fall back to mmapping `UInt8` and returning a `ReinterpretedArray` when direct mmapping is not possible.

closes #648