### PR TITLE
Fix hash function definition

### DIFF
--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -161,7 +161,7 @@ end
 Base.:(==)(x::CompoundDatatype, y::CompoundDatatype) =
     x.size == y.size && x.names == y.names && x.offsets == y.offsets &&
     x.members == y.members
-Base.hash(::CompoundDatatype) = throw(ArgumentError("hash not defined for CompoundDatatype"))
+Base.hash(::CompoundDatatype, u::UInt) = throw(ArgumentError("hash not defined for CompoundDatatype"))
 
 class(dt::CompoundDatatype) = DT_COMPOUND
 function jlsizeof(dt::CompoundDatatype)
@@ -254,7 +254,7 @@ Base.:(==)(x::VariableLengthDatatype, y::VariableLengthDatatype) =
     x.class<<4 == y.class<<4 && x.bitfield1 == y.bitfield1 &&
     x.bitfield2 == y.bitfield2 && x.size == y.size &&
     x.basetype == y.basetype
-Base.hash(::VariableLengthDatatype) = throw(ArgumentError("hash not defined for CompoundDatatype"))
+Base.hash(::VariableLengthDatatype, u::UInt) = throw(ArgumentError("hash not defined for CompoundDatatype"))
 
 class(dt::VariableLengthDatatype) = dt.class
 jlsizeof(dt::VariableLengthDatatype) =

--- a/src/types.jl
+++ b/src/types.jl
@@ -148,7 +148,7 @@ define_packed(RelOffset)
 
 RelOffset(r::RelOffset) = r
 Base.:(==)(x::RelOffset, y::RelOffset) = x === y
-Base.hash(x::RelOffset) = hash(x.offset)
+Base.hash(x::RelOffset, u::UInt) = hash(x.offset, u)
 Base.:(+)(x::RelOffset, y::Integer) = RelOffset(UInt64(x.offset + y))
 Base.:(-)(x::RelOffset, y::Integer) = RelOffset(UInt64(x.offset - y))
 


### PR DESCRIPTION
As said in the [documentation](https://docs.julialang.org/en/v1/base/base/#Base.hash)

> New types should implement the 2-argument form, typically by calling the 2-argument hash method recursively in order to mix hashes of the contents with each other (and with h).

Otherwise, it causes [invalidations](https://julialang.org/blog/2020/08/invalidations/). Initially spot on in RxInfer (that uses GraphPPL that uses MetaGraphsNext that uses JLD2) when analyzing latency issues on upcoming Julia 1.12. Would be nice to tag a new patch release after this is merged 

Before this PR 
<img width="1113" height="345" alt="image" src="https://github.com/user-attachments/assets/95e62326-19b4-414f-a761-572e7922f8c2" />

After this PR
<img width="706" height="131" alt="image" src="https://github.com/user-attachments/assets/a93306c6-a564-4bcc-ad3c-2f8203f1f39a" />
