### PR TITLE
bump compat for ChunkCodecLibBzip2 and ChunkCodecLibLz4 to 0.3

### DIFF
--- a/filterpkgs/JLD2Bzip2/Project.toml
+++ b/filterpkgs/JLD2Bzip2/Project.toml
@@ -8,6 +8,6 @@ ChunkCodecLibBzip2 = "2b723af9-f480-4e8d-a1e4-4a9f5a906122"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 
 [compat]
-ChunkCodecLibBzip2 = "0.2.1"
+ChunkCodecLibBzip2 = "0.2.1, 0.3"
 JLD2 = "0.6"
 julia = "1.9"

--- a/filterpkgs/JLD2Lz4/Project.toml
+++ b/filterpkgs/JLD2Lz4/Project.toml
@@ -8,6 +8,6 @@ ChunkCodecLibLz4 = "7e9cc85e-5614-42a3-ad86-b78f920b38a5"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 
 [compat]
-ChunkCodecLibLz4 = "0.2.2"
+ChunkCodecLibLz4 = "0.2.2, 0.3"
 JLD2 = "0.6"
 julia = "1.9"


### PR DESCRIPTION
The changes are to functions that are not used here.