### PR TITLE
Bump compat for ChunkCodec packages to v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,8 +19,8 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 UnPackExt = "UnPack"
 
 [compat]
-ChunkCodecLibZlib = "0.2.1, 0.3"
-ChunkCodecLibZstd = "0.2.1, 0.3"
+ChunkCodecLibZlib = "1"
+ChunkCodecLibZstd = "1"
 FileIO = "1.5.1"
 MacroTools = "0.5.10"
 OrderedCollections = "1"

--- a/filterpkgs/JLD2Bzip2/Project.toml
+++ b/filterpkgs/JLD2Bzip2/Project.toml
@@ -8,6 +8,6 @@ ChunkCodecLibBzip2 = "2b723af9-f480-4e8d-a1e4-4a9f5a906122"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 
 [compat]
-ChunkCodecLibBzip2 = "0.2.1, 0.3"
+ChunkCodecLibBzip2 = "1"
 JLD2 = "0.6"
 julia = "1.9"

--- a/filterpkgs/JLD2Lz4/Project.toml
+++ b/filterpkgs/JLD2Lz4/Project.toml
@@ -8,6 +8,6 @@ ChunkCodecLibLz4 = "7e9cc85e-5614-42a3-ad86-b78f920b38a5"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 
 [compat]
-ChunkCodecLibLz4 = "0.2.2, 0.3"
+ChunkCodecLibLz4 = "1"
 JLD2 = "0.6"
 julia = "1.9"


### PR DESCRIPTION
This version has no changes; it was to mark the API as stable.