### PR TITLE
Improve filter docs

### DIFF
--- a/filterpkgs/JLD2Bzip2/src/JLD2Bzip2.jl
+++ b/filterpkgs/JLD2Bzip2/src/JLD2Bzip2.jl
@@ -9,13 +9,29 @@ module JLD2Bzip2
 using JLD2: JLD2, Filters
 using ChunkCodecLibBzip2
 
+"""
+    Bzip2Filter <: Filter
+
+The Bzip2Filter can be used to compress datasets using the bzip2 compression algorithm.
+This is filter id 307.
+
+## Arguments
+- `blocksize100k`: Specifies the block size to be used for compression.
+
+  It should be a value between 1 and 9 inclusive, and the actual block size used
+  is 100000 x this figure. The default 9 gives the best compression but takes the most memory.
+
+# External Links
+* [BZIP2 HDF5 Filter ID 307](https://github.com/HDFGroup/hdf5_plugins/blob/master/docs/RegisteredFilterPlugins.md)
+* [BZIP2 HDF5 Plugin Repository (C code)](https://github.com/HDFGroup/hdf5_plugins/tree/master/BZIP2/src)
+"""
 struct Bzip2Filter <: Filters.Filter
     blocksize100k::Cuint
 end
 Bzip2Filter() = Bzip2Filter(9)
 
 Filters.filterid(::Type{Bzip2Filter}) = UInt16(307)
-Filters.filtername(::Type{Bzip2Filter}) = "HDF5 bzip2 filter; see http://www.hdfgroup.org/services/contributions.html"
+Filters.filtername(::Type{Bzip2Filter}) = "BZIP2"
 Filters.client_values(filter::Bzip2Filter) = (filter.blocksize100k, )
 Filters.filtertype(::Val{307}) = Bzip2Filter
 

--- a/filterpkgs/JLD2Lz4/src/JLD2Lz4.jl
+++ b/filterpkgs/JLD2Lz4/src/JLD2Lz4.jl
@@ -16,8 +16,8 @@ const DEFAULT_BLOCK_SIZE = 1 << 30
 Apply LZ4 compression. `blocksize` is the main argument. The filter id is 32004.
 
 # External Links
-* [LZ4 HDF5 Filter ID 32004](https://portal.hdfgroup.org/display/support/Filters#Filters-32004)
-* [LZ4 HDF5 Plugin Repository (C code)](https://github.com/nexusformat/HDF5-External-Filter-Plugins/tree/master/LZ4)
+* [LZ4 HDF5 Filter ID 32004](https://github.com/HDFGroup/hdf5_plugins/blob/master/docs/RegisteredFilterPlugins.md)
+* [LZ4 HDF5 Plugin Repository (C code)](https://github.com/HDFGroup/hdf5_plugins/tree/master/LZ4/src)
 """
 struct Lz4Filter <: Filters.Filter
     blocksize::Cuint
@@ -26,7 +26,7 @@ Lz4Filter() = Lz4Filter(DEFAULT_BLOCK_SIZE)
 
 
 Filters.filterid(::Type{Lz4Filter}) = UInt16(32004)
-Filters.filtername(::Type{Lz4Filter}) = "HDF5 lz4 filter; see http://www.hdfgroup.org/services/contributions.html"
+Filters.filtername(::Type{Lz4Filter}) = "LZ4H5"
 Filters.client_values(filter::Lz4Filter) = (filter.blocksize, )
 Filters.filtertype(::Val{32004}) = Lz4Filter
 

--- a/src/Filters.jl
+++ b/src/Filters.jl
@@ -182,6 +182,7 @@ struct Shuffle <: Filter
     element_size::UInt32
 end
 Shuffle() = Shuffle(0)
+filtername(::Type{Shuffle}) = ""
 filterid(::Type{Shuffle}) = UInt16(2)
 client_values(filter::Shuffle) = (filter.element_size,)
 filtertype(::Val{2}) = Shuffle
@@ -273,7 +274,7 @@ struct ZstdFilter <: Filter
 end
 
 filterid(::Type{ZstdFilter}) = UInt16(32015)
-filtername(::Type{ZstdFilter}) = "Zstandard compression: http://www.zstd.net"
+filtername(::Type{ZstdFilter}) = "ZSTD"
 client_values(filter::ZstdFilter) = (filter.level, )
 filtertype(::Val{32015}) = ZstdFilter
 


### PR DESCRIPTION
This PR adds a docstring for `Bzip2Filter`, fixes some urls, and also shortens the `filtername` for the filters.

The `filtername` is for debug purposes.
Since the `filtername` is stored in the .jld2 file, a long name adds to the overhead of using compression on small arrays.