### PR TITLE
Improve filter constructor docs

### DIFF
--- a/docs/src/compression.md
+++ b/docs/src/compression.md
@@ -118,11 +118,11 @@ Different filters support various configuration options:
 using JLD2, JLD2Lz4, JLD2Bzip2
 
 # Zstd with different compression levels
-zstd_fast = ZstdFilter(1)    # Fast compression
-zstd_best = ZstdFilter(22)   # Best compression
+zstd_fast = ZstdFilter(level=1)    # Fast compression
+zstd_best = ZstdFilter(level=22)   # Best compression
 
 # Bzip2 with custom block size
-bzip2_filter = Bzip2Filter(4)
+bzip2_filter = Bzip2Filter(blocksize100k=4)
 
 # Example usage
 jldopen("example.jld2", "w") do f
@@ -156,7 +156,7 @@ jldopen("example.jld2", "w"; compress=ZstdFilter()) do f
     write(f, "zlib_array", zeros(10000); compress=Deflate())
 
     # Alternatively, use the same filter but with different configuration
-    write(f, "fast_compressed", rand(10000); compress=ZstdFilter(1))
+    write(f, "fast_compressed", rand(10000); compress=ZstdFilter(level= -20))
 end
 ```
 

--- a/filterpkgs/JLD2Bzip2/src/JLD2Bzip2.jl
+++ b/filterpkgs/JLD2Bzip2/src/JLD2Bzip2.jl
@@ -15,8 +15,8 @@ using ChunkCodecLibBzip2
 The Bzip2Filter can be used to compress datasets using the bzip2 compression algorithm.
 This is filter id 307.
 
-## Arguments
-- `blocksize100k`: Specifies the block size to be used for compression.
+## Keyword arguments:
+- `blocksize100k::Integer = 9`: Specifies the block size to be used for compression.
 
   It should be a value between 1 and 9 inclusive, and the actual block size used
   is 100000 x this figure. The default 9 gives the best compression but takes the most memory.
@@ -28,7 +28,7 @@ This is filter id 307.
 struct Bzip2Filter <: Filters.Filter
     blocksize100k::Cuint
 end
-Bzip2Filter(; blocksize100k=9) = Bzip2Filter(blocksize100k)
+Bzip2Filter(; blocksize100k::Integer=9) = Bzip2Filter(blocksize100k)
 
 Filters.filterid(::Type{Bzip2Filter}) = UInt16(307)
 Filters.filtername(::Type{Bzip2Filter}) = "BZIP2"

--- a/filterpkgs/JLD2Lz4/src/JLD2Lz4.jl
+++ b/filterpkgs/JLD2Lz4/src/JLD2Lz4.jl
@@ -11,9 +11,14 @@ using ChunkCodecLibLz4
 const DEFAULT_BLOCK_SIZE = 1 << 30
 
 """
-    Lz4Filter(blocksize)
 
-Apply LZ4 compression. `blocksize` is the main argument. The filter id is 32004.
+    Lz4Filter <: Filter
+
+The Lz4Filter can be used to compress datasets using the lz4 compression algorithm.
+This is filter id 32004.
+
+## Keyword arguments:
+- `blocksize::Integer = 2^30`: Block size in bytes at most 2,113,929,216 bytes. Default is 1 GiB.
 
 # External Links
 * [LZ4 HDF5 Filter ID 32004](https://github.com/HDFGroup/hdf5_plugins/blob/master/docs/RegisteredFilterPlugins.md)
@@ -22,7 +27,7 @@ Apply LZ4 compression. `blocksize` is the main argument. The filter id is 32004.
 struct Lz4Filter <: Filters.Filter
     blocksize::Cuint
 end
-Lz4Filter(; blocksize=DEFAULT_BLOCK_SIZE) = Lz4Filter(blocksize)
+Lz4Filter(; blocksize::Integer=DEFAULT_BLOCK_SIZE) = Lz4Filter(blocksize)
 
 
 Filters.filterid(::Type{Lz4Filter}) = UInt16(32004)


### PR DESCRIPTION
Follow-up on #682

Additionally, this PR removes the keyword argument constructor for the shuffle filter, as the element size is set automatically based on the size of the data type.