### PR TITLE
Fix HDF5 v2 compatibility: write correct chunk dimension encoding length

### DIFF
--- a/src/datalayouts.jl
+++ b/src/datalayouts.jl
@@ -31,7 +31,9 @@ function DataLayout(f::JLD2.JLDFile, msg::HmWrap{HmDataLayout})
             data_length = Int64(msg.data_size)
             return DataLayout(version, storage_type, data_length, data_offset) 
         elseif version == 4 && storage_type == LcChunked
-            chunk_dimensions = Int[msg.dimensions...]
+            dsz = Int(msg.dim_size)
+            buf = IOBuffer(msg.chunk_dims_raw)
+            chunk_dimensions = [Int(read_nb_uint(buf, dsz)) for _ in 1:Int(msg.dimensionality)]
             chunk_indexing_type = msg.chunk_indexing_type
             chunk_indexing_type == 1 || throw(UnsupportedFeatureException("Unknown chunk indexing type"))
             data_length = Int64(msg.data_size)

--- a/src/headermessages.jl
+++ b/src/headermessages.jl
@@ -123,8 +123,11 @@ end
         if version == 4 && layout_class == LcChunked
             flags::UInt8 = 2 # Single index with filter
             dimensionality::UInt8 = length(kw.dimensions)
-            dim_size::UInt8 = 8 # 8 bytes per dimension
-            dimensions::NTuple{Int(dimensionality), uintofsize(dim_size)}
+            dim_size::UInt8 = let md = Int(maximum(kw.dimensions)); UInt8((ndigits(md, base=2) + 7) ÷ 8) end
+            chunk_dims_raw::@Blob(Int(dimensionality) * Int(dim_size)) = let dsz = Int(dim_size), buf = IOBuffer()
+                foreach(d -> write_nb_int(buf, d, dsz), kw.dimensions)
+                take!(buf)
+            end
             chunk_indexing_type::UInt8 = 1 # Single Chunk
             if chunk_indexing_type == 1 # Single Chunk
                 data_size::@Int(8)#Int64 # Lengths


### PR DESCRIPTION
HDF5 v2.1+ strictly validates that the `Dimension Size Encoded Length` field in the v4 Data Layout message matches the minimum number of bytes needed to represent the largest chunk dimension:

  dim_size = ceil(bit_length(max_dim) / 8)

Previously JLD2 hardcoded `dim_size = 8` and stored each dimension as a full UInt64, which HDF5 v1.x accepted but HDF5 v2 rejects with: "stored chunk dimension encoding length does not match value calculated from chunk dimensions"

The fix computes the exact encoding size and stores dimensions as `dim_size`-byte little-endian integers using `write_nb_int`/`read_nb_uint`. Note that `dim_size` is NOT always a power of 2 — e.g. arrays with 65 536–16 777 215 elements require `dim_size = 3`.

Fixes JuliaIO/HDF5.jl#1224